### PR TITLE
Task cells displayed while searching are now of appropriate height. (Closes #32)

### DIFF
--- a/Classes/todo_txt_touch_iosViewController.m
+++ b/Classes/todo_txt_touch_iosViewController.m
@@ -220,7 +220,8 @@
 
 // Return the height for tableview cells
 -(CGFloat) tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    return [FlexiTaskCell heightForCellWithTask:[tasks objectAtIndex:indexPath.row]];
+    Task* task = [self taskForTable:tableView atIndex:indexPath.row];
+    return [FlexiTaskCell heightForCellWithTask:task];
 }
 
 // Load the detail view controller when user taps the row


### PR DESCRIPTION
Test with a long task name. Refer to issue #32 [https://github.com/ginatrapani/todo.txt-touch-ios/issues/32]
