### PR TITLE
Use "iPhone Developer" automatic profile selection for debug builds

### DIFF
--- a/todo.txt-touch-ios.xcodeproj/project.pbxproj
+++ b/todo.txt-touch-ios.xcodeproj/project.pbxproj
@@ -1043,14 +1043,15 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CODE_SIGN_ENTITLEMENTS = "";
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				PRODUCT_NAME = Todo.txt;
 				PROVISIONING_PROFILE = "";
+				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
 			};
 			name = Debug;


### PR DESCRIPTION
I just set the code signing identity for debug build to the auto-selector for "iPhone Developer" so that people can use their developer profile and automatic provisioning as you would expect for debug builds on their own devices.
