### PR TITLE
Fix help screen in landscape

### DIFF
--- a/Classes/ActionSheetPicker.m
+++ b/Classes/ActionSheetPicker.m
@@ -176,10 +176,10 @@
         
         if (self.barButtonItem) {
 			[self.popOverController presentPopoverFromBarButtonItem:self.barButtonItem
-                                       permittedArrowDirections:UIPopoverArrowDirectionDown animated:YES];
+                                       permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
 		} else {
 			[self.popOverController presentPopoverFromRect:self.rect inView:self.view
-										   permittedArrowDirections:UIPopoverArrowDirectionDown animated:YES];
+										   permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
 		}
 	} else {
 		//spawn actionsheet

--- a/Classes/SSTextView.h
+++ b/Classes/SSTextView.h
@@ -1,0 +1,28 @@
+//
+//  SSTextView.h
+//  SSToolkit
+//
+//  Created by Sam Soffes on 8/18/10.
+//  Copyright 2010-2011 Sam Soffes. All rights reserved.
+//
+
+/**
+ UITextView subclass that adds placeholder support like UITextField has.
+ */
+@interface SSTextView : UITextView
+
+/**
+ The string that is displayed when there is no other text in the text view.
+ 
+ The default value is `nil`.
+ */
+@property (nonatomic, retain) NSString *placeholder;
+
+/**
+ The color of the placeholder.
+ 
+ The default is `[UIColor lightGrayColor]`.
+ */
+@property (nonatomic, retain) UIColor *placeholderColor;
+
+@end

--- a/Classes/SSTextView.m
+++ b/Classes/SSTextView.m
@@ -1,0 +1,109 @@
+//
+//  SSTextView.m
+//  SSToolkit
+//
+//  Created by Sam Soffes on 8/18/10.
+//  Copyright 2010-2011 Sam Soffes. All rights reserved.
+//
+
+#import "SSTextView.h"
+
+@interface SSTextView ()
+- (void)_initialize;
+- (void)_updateShouldDrawPlaceholder;
+- (void)_textChanged:(NSNotification *)notification;
+@end
+
+
+@implementation SSTextView {
+	BOOL _shouldDrawPlaceholder;
+}
+
+
+#pragma mark - Accessors
+
+@synthesize placeholder = _placeholder;
+@synthesize placeholderColor = _placeholderColor;
+
+- (void)setText:(NSString *)string {
+	[super setText:string];
+	[self _updateShouldDrawPlaceholder];
+}
+
+
+- (void)setPlaceholder:(NSString *)string {
+	if ([string isEqual:_placeholder]) {
+		return;
+	}
+	
+	[_placeholder release];
+	_placeholder = [string retain];
+	
+	[self _updateShouldDrawPlaceholder];
+}
+
+
+#pragma mark - NSObject
+
+- (void)dealloc {
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:UITextViewTextDidChangeNotification object:self];
+	
+	[_placeholder release];
+	[_placeholderColor release];
+	[super dealloc];
+}
+
+
+#pragma mark - UIView
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+	if ((self = [super initWithCoder:aDecoder])) {
+		[self _initialize];
+	}
+	return self;
+}
+
+
+- (id)initWithFrame:(CGRect)frame {
+	if ((self = [super initWithFrame:frame])) {
+		[self _initialize];
+	}
+	return self;
+}
+
+
+- (void)drawRect:(CGRect)rect {
+	[super drawRect:rect];
+	
+	if (_shouldDrawPlaceholder) {
+		[_placeholderColor set];
+		[_placeholder drawInRect:CGRectMake(8.0f, 8.0f, self.frame.size.width - 16.0f, self.frame.size.height - 16.0f) withFont:self.font];
+	}
+}
+
+
+#pragma mark - Private
+
+- (void)_initialize {
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_textChanged:) name:UITextViewTextDidChangeNotification object:self];
+	
+	self.placeholderColor = [UIColor colorWithWhite:0.702f alpha:1.0f];
+	_shouldDrawPlaceholder = NO;
+}
+
+
+- (void)_updateShouldDrawPlaceholder {
+	BOOL prev = _shouldDrawPlaceholder;
+	_shouldDrawPlaceholder = self.placeholder && self.placeholderColor && self.text.length == 0;
+	
+	if (prev != _shouldDrawPlaceholder) {
+		[self setNeedsDisplay];
+	}
+}
+
+
+- (void)_textChanged:(NSNotification *)notificaiton {
+	[self _updateShouldDrawPlaceholder];	
+}
+
+@end

--- a/Classes/TaskEditViewController.h
+++ b/Classes/TaskEditViewController.h
@@ -75,6 +75,7 @@
 	UIButton *helpCloseButton;
 	UIPopoverController *popOverController;
 	ActionSheetPicker *actionSheetPicker;
+	UIWebView* helpContents;
 }
 
 @property (nonatomic, assign) id <TaskEditViewControllerDelegate> delegate;
@@ -83,6 +84,7 @@
 @property (nonatomic, assign) IBOutlet UIView *accessoryView;
 @property (nonatomic, retain) Task *task;
 @property (nonatomic, retain) IBOutlet UIView *helpView;
+@property (nonatomic, retain) IBOutlet UIView *helpContents;
 @property (nonatomic, retain) IBOutlet UIButton *helpCloseButton;
 @property (nonatomic, retain) UIPopoverController *popOverController;
 @property (nonatomic, retain) ActionSheetPicker *actionSheetPicker;

--- a/Classes/TaskEditViewController.h
+++ b/Classes/TaskEditViewController.h
@@ -51,6 +51,7 @@
 #import "Task.h"
 #import "TestFlight.h"
 #import "ActionSheetPicker.h"
+#import "SSTextView.h"
 
 @class TaskEditViewController;
 
@@ -65,7 +66,7 @@
 @interface TaskEditViewController : UIViewController <UITextViewDelegate>{
 	 id <TaskEditViewControllerDelegate> delegate;
 	UINavigationItem *navItem;
-	UITextView *textView; 
+	SSTextView *textView; 
 	UIView *accessoryView;
 	NSString *curInput;
 	Task *task;
@@ -78,7 +79,7 @@
 
 @property (nonatomic, assign) id <TaskEditViewControllerDelegate> delegate;
 @property (nonatomic, retain) IBOutlet UINavigationItem *navItem;
-@property (nonatomic, retain) IBOutlet UITextView *textView;
+@property (nonatomic, retain) IBOutlet SSTextView *textView;
 @property (nonatomic, assign) IBOutlet UIView *accessoryView;
 @property (nonatomic, retain) Task *task;
 @property (nonatomic, retain) IBOutlet UIView *helpView;

--- a/Classes/TaskEditViewController.m
+++ b/Classes/TaskEditViewController.m
@@ -107,7 +107,7 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 
 @implementation TaskEditViewController
 
-@synthesize delegate, navItem, textView, accessoryView, task, helpView, helpCloseButton, popOverController, actionSheetPicker;
+@synthesize delegate, navItem, textView, accessoryView, task, helpView, helpContents, helpCloseButton, popOverController, actionSheetPicker;
 
 // The designated initializer.  Override if you create the controller programmatically and want to perform customization that is not appropriate for viewDidLoad.
 /*
@@ -128,6 +128,12 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 	
 	textView.placeholder = @"Call Mom @phone +FamilialPeace";
 	
+	[helpContents loadHTMLString:@"<html><head><style>body { -webkit-text-size-adjust: none; color: white; font-family: Helvetica; font-size: 14pt;} </style></head><body>"
+	 "<p><strong>Projects</strong> start with a + sign and contain no spaces, like +KitchenRemodel or +Novel.</p>"
+	 "<p><strong>Contexts</strong> (where you will complete a task) start with an @ sign, like @phone or @GroceryStore."
+	 "<p>A task can include any number of projects or contexts.</p>"
+	 "</body></html>"
+						 baseURL:nil];
 	helpCloseButton.layer.cornerRadius = 8.0f;
 	helpCloseButton.layer.masksToBounds = YES;
 	helpCloseButton.layer.borderWidth = 1.0f;
@@ -380,6 +386,7 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 	self.navItem = nil;
 	self.task = nil;
 	self.helpView = nil;
+	self.helpContents = nil;
 	self.helpCloseButton = nil;
 	self.popOverController = nil;
 	self.actionSheetPicker = nil;
@@ -389,6 +396,7 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 	[navItem release];
 	[textView release];
 	[helpView release];
+	[helpContents release];
 	[helpCloseButton release];
 	[popOverController release];
 	[actionSheetPicker release];

--- a/Classes/TaskEditViewController.m
+++ b/Classes/TaskEditViewController.m
@@ -247,7 +247,13 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 		[animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn]];
 		[[self.view layer] addAnimation:animation forKey:kCATransitionReveal];
 		
-		const CGRect rect = (CGRect){CGPointZero,self.view.frame.size};
+		CGSize size;
+		if (self.interfaceOrientation == UIDeviceOrientationPortrait) {
+			size = CGSizeMake(self.view.frame.size.width, self.view.frame.size.height);
+		} else {
+			size = CGSizeMake(self.view.frame.size.height, self.view.frame.size.width);			
+		}
+		const CGRect rect = (CGRect){CGPointZero,size};		
 		helpView.frame  = rect;
 		helpCloseButton.hidden = NO;
 		[self.view addSubview:helpView];

--- a/Classes/TaskEditViewController.m
+++ b/Classes/TaskEditViewController.m
@@ -232,15 +232,24 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 }
 
 - (IBAction)helpButtonPressed:(id)sender {
+	// Close help view if necessary
+	[self.popOverController dismissPopoverAnimated:NO];
+	
 	// Display help text
 	if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+		CGSize size;
+		if (self.interfaceOrientation == UIDeviceOrientationPortrait) {
+			size = CGSizeMake(320, 380);
+		} else {
+			size = CGSizeMake(460, 300);			
+		}
+		const CGRect rect = (CGRect){CGPointZero,size};		
+		helpView.frame  = rect;
 		//spawn popovercontroller
-		if (popOverController == nil) {
-			UIViewController *viewController = [[[UIViewController alloc] initWithNibName:nil bundle:nil] autorelease];
-			viewController.view = helpView;
-			viewController.contentSizeForViewInPopover = viewController.view.frame.size;
-			popOverController = [[UIPopoverController alloc] initWithContentViewController:viewController];
-		}	
+		UIViewController *viewController = [[[UIViewController alloc] initWithNibName:nil bundle:nil] autorelease];
+		viewController.view = helpView;
+		viewController.contentSizeForViewInPopover = viewController.view.frame.size;
+		self.popOverController = [[UIPopoverController alloc] initWithContentViewController:viewController];
 		helpCloseButton.hidden = YES;
         [popOverController presentPopoverFromBarButtonItem:sender
                                        permittedArrowDirections:UIPopoverArrowDirectionDown animated:YES];
@@ -406,5 +415,12 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
  return YES;
 }
+
+- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
+	[popOverController dismissPopoverAnimated:NO];
+	[actionSheetPicker actionPickerCancel];
+	self.actionSheetPicker = nil;
+}
+
 
 @end

--- a/Classes/TaskEditViewController.m
+++ b/Classes/TaskEditViewController.m
@@ -126,6 +126,8 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
     [super viewDidLoad];
 	curInput = [[NSString alloc] init];	
 	
+	textView.placeholder = @"Call Mom @phone +FamilialPeace";
+	
 	helpCloseButton.layer.cornerRadius = 8.0f;
 	helpCloseButton.layer.masksToBounds = YES;
 	helpCloseButton.layer.borderWidth = 1.0f;

--- a/Classes/TaskViewController.h
+++ b/Classes/TaskViewController.h
@@ -51,14 +51,17 @@
 #import <UIKit/UIKit.h>
 #import "Task.h"
 #import "TestFlight.h"
+#import "ActionSheetPicker.h"
 
 @interface TaskViewController : UITableViewController <UIActionSheetDelegate> {
     NSInteger taskIndex;
 	UITableViewCell *tableCell; 
+	ActionSheetPicker *actionSheetPicker;
 }
 
 @property (nonatomic, assign) NSInteger taskIndex;
 @property (nonatomic, retain) IBOutlet UITableViewCell *tableCell;
+@property (nonatomic, retain) ActionSheetPicker *actionSheetPicker;
 
 - (void) didTapCompleteButton;
 - (void) didTapPrioritizeButton;

--- a/Classes/TaskViewController.m
+++ b/Classes/TaskViewController.m
@@ -67,7 +67,7 @@ char *completed_buttons[] = { "Undo Complete", "Delete" };
 
 @implementation TaskViewController
 
-@synthesize taskIndex, tableCell;
+@synthesize taskIndex, tableCell, actionSheetPicker;
 
 - (Task*) task {
 	return [[todo_txt_touch_iosAppDelegate sharedTaskBag] taskAtIndex:taskIndex];
@@ -401,9 +401,10 @@ char *completed_buttons[] = { "Undo Complete", "Delete" };
 
 - (void) didTapPrioritizeButton {
 	NSLog(@"didTapPrioritizeButton called");
+	[actionSheetPicker actionPickerCancel];
 	NSInteger curPriority = (NSInteger)[[[self task] priority] name];
 	UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:1]]; //FIXME: don't hardcode this
-	[ActionSheetPicker displayActionPickerWithView:self.view 
+	self.actionSheetPicker = [ActionSheetPicker displayActionPickerWithView:self.view 
 						data:[Priority allCodes]
 						selectedIndex:curPriority 
 						target:self 
@@ -461,10 +462,17 @@ char *completed_buttons[] = { "Undo Complete", "Delete" };
 
 - (void) dealloc {;
 	[super dealloc];
+	[actionSheetPicker release];
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
     return YES;
 }
+
+- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
+	[actionSheetPicker actionPickerCancel];
+	self.actionSheetPicker = nil;
+}
+
 
 @end

--- a/Classes/todo_txt_touch_iosViewController.h
+++ b/Classes/todo_txt_touch_iosViewController.h
@@ -78,7 +78,8 @@
 
 - (IBAction)addButtonPressed:(id)sender;
 - (IBAction)syncButtonPressed:(id)sender;
-- (IBAction)segmentControlPressed:(id)sender;
+//- (IBAction)segmentControlPressed:(id)sender;
+- (IBAction)sortButtonPressed:(id)sender;
 - (IBAction)settingsButtonPressed:(id)sender;
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath;
 - (UITableViewCellAccessoryType)tableView:(UITableView *)tableView accessoryTypeForRowWithIndexPath:(NSIndexPath *)indexPath;

--- a/Classes/todo_txt_touch_iosViewController.m
+++ b/Classes/todo_txt_touch_iosViewController.m
@@ -167,6 +167,11 @@
 	UIBarButtonItem *addButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(addButtonPressed:)];          
 	self.navigationItem.rightBarButtonItem = addButton;
 	[addButton release];
+	
+	UIBarButtonItem *sortButton = [[UIBarButtonItem alloc] initWithTitle:@"Sort" style:UIBarButtonItemStyleBordered target:self action:@selector(sortButtonPressed:)];          
+	self.navigationItem.leftBarButtonItem = sortButton;
+	[sortButton release];
+
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -356,27 +361,40 @@ shouldReloadTableForSearchString:(NSString *)searchString
 	}
 }
 
-- (IBAction)segmentControlPressed:(id)sender {
+//- (IBAction)segmentControlPressed:(id)sender {
+//	[actionSheetPicker actionPickerCancel];
+//	self.actionSheetPicker = nil;
+//	UISegmentedControl *segmentedControl = (UISegmentedControl *)sender;
+//	CGRect rect = [self.view convertRect:segmentedControl.frame fromView:segmentedControl];
+//	rect = CGRectMake(segmentedControl.frame.origin.x + segmentedControl.frame.size.width / 4, rect.origin.y, 
+//					  rect.size.width, rect.size.height);
+//	switch (segmentedControl.selectedSegmentIndex) {
+//		case 0: // Filter
+//			break;
+//		case 1: // Sort
+//			self.actionSheetPicker = [ActionSheetPicker displayActionPickerWithView:self.view 
+//																			   data:[Sort descriptions]
+//																	  selectedIndex:[sort name]
+//																			 target:self 
+//																			 action:@selector(sortOrderWasSelected::) 
+//																			  title:@"Select Sort Order"
+//																			   rect:rect
+//																	  barButtonItem:nil];			
+//			break;
+//	}
+//}
+
+- (IBAction)sortButtonPressed:(id)sender {
 	[actionSheetPicker actionPickerCancel];
 	self.actionSheetPicker = nil;
-	UISegmentedControl *segmentedControl = (UISegmentedControl *)sender;
-	CGRect rect = [self.view convertRect:segmentedControl.frame fromView:segmentedControl];
-	rect = CGRectMake(segmentedControl.frame.origin.x + segmentedControl.frame.size.width / 4, rect.origin.y, 
-					  rect.size.width, rect.size.height);
-	switch (segmentedControl.selectedSegmentIndex) {
-		case 0: // Filter
-			break;
-		case 1: // Sort
-			self.actionSheetPicker = [ActionSheetPicker displayActionPickerWithView:self.view 
-					data:[Sort descriptions]
-					selectedIndex:[sort name]
-					target:self 
-					action:@selector(sortOrderWasSelected::) 
-					 title:@"Select Sort Order"
-					  rect:rect
-			 barButtonItem:nil];			
-			break;
-	}
+	self.actionSheetPicker = [ActionSheetPicker displayActionPickerWithView:self.view 
+																	   data:[Sort descriptions]
+															  selectedIndex:[sort name]
+																	 target:self 
+																	 action:@selector(sortOrderWasSelected::) 
+																	  title:@"Select Sort Order"
+																	   rect:CGRectZero
+															  barButtonItem:sender];			
 }
 
 - (void)didReceiveMemoryWarning {

--- a/TaskEditViewController.xib
+++ b/TaskEditViewController.xib
@@ -14,8 +14,8 @@
 			<bool key="EncodedWithXMLCoder">YES</bool>
 			<string>IBProxyObject</string>
 			<string>IBUIBarButtonItem</string>
-			<string>IBUILabel</string>
 			<string>IBUIButton</string>
+			<string>IBUIWebView</string>
 			<string>IBUITextView</string>
 			<string>IBUINavigationItem</string>
 			<string>IBUINavigationBar</string>
@@ -64,11 +64,11 @@
 							<int key="IBUIKeyboardType">7</int>
 							<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						</object>
-						<object class="IBUIFontDescription" key="IBUIFontDescription" id="191406775">
+						<object class="IBUIFontDescription" key="IBUIFontDescription">
 							<int key="type">1</int>
 							<double key="pointSize">17</double>
 						</object>
-						<object class="NSFont" key="IBUIFont" id="346983120">
+						<object class="NSFont" key="IBUIFont">
 							<string key="NSName">Helvetica</string>
 							<double key="NSSize">17</double>
 							<int key="NSfFlags">16</int>
@@ -123,151 +123,6 @@
 				<int key="NSvFlags">274</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
-					<object class="IBUILabel" id="516451120">
-						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">298</int>
-						<string key="NSFrame">{{49, 87}, {76, 22}}</string>
-						<reference key="NSSuperview" ref="791280918"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="666484715"/>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">Projects</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MSAxIDEAA</bytes>
-							<object class="NSColorSpace" key="NSCustomColorSpace" id="403207145">
-								<int key="NSID">1</int>
-							</object>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<object class="NSColor" key="IBUIShadowColor" id="368085276">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MCAwIDAAA</bytes>
-						</object>
-						<int key="IBUIBaselineAdjustment">1</int>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-						<float key="IBUIMinimumFontSize">10</float>
-						<object class="IBUIFontDescription" key="IBUIFontDescription" id="283122791">
-							<int key="type">2</int>
-							<double key="pointSize">17</double>
-						</object>
-						<object class="NSFont" key="IBUIFont" id="520127283">
-							<string key="NSName">Helvetica-Bold</string>
-							<double key="NSSize">17</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-					<object class="IBUILabel" id="666484715">
-						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">298</int>
-						<string key="NSFrame">{{49, 87}, {223, 63}}</string>
-						<reference key="NSSuperview" ref="791280918"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="602818637"/>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">               start with a + sign and contain no spaces, like +KitchenRemodel or +Novel.</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MSAxIDEAA</bytes>
-							<reference key="NSCustomColorSpace" ref="403207145"/>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">1</int>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-						<float key="IBUIMinimumFontSize">10</float>
-						<int key="IBUINumberOfLines">0</int>
-						<int key="IBUILineBreakMode">0</int>
-						<reference key="IBUIFontDescription" ref="191406775"/>
-						<reference key="IBUIFont" ref="346983120"/>
-					</object>
-					<object class="IBUILabel" id="602818637">
-						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">298</int>
-						<string key="NSFrame">{{49, 173}, {76, 22}}</string>
-						<reference key="NSSuperview" ref="791280918"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="99457092"/>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">Contexts</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MSAxIDEAA</bytes>
-							<reference key="NSCustomColorSpace" ref="403207145"/>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<reference key="IBUIShadowColor" ref="368085276"/>
-						<int key="IBUIBaselineAdjustment">1</int>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-						<float key="IBUIMinimumFontSize">10</float>
-						<reference key="IBUIFontDescription" ref="283122791"/>
-						<reference key="IBUIFont" ref="520127283"/>
-					</object>
-					<object class="IBUILabel" id="99457092">
-						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">298</int>
-						<string key="NSFrame">{{49, 173}, {222, 84}}</string>
-						<reference key="NSSuperview" ref="791280918"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="185383553"/>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">                (where you will complete a task) start with an @ sign, like @phone or @GroceryStore.</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MSAxIDEAA</bytes>
-							<reference key="NSCustomColorSpace" ref="403207145"/>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">1</int>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-						<float key="IBUIMinimumFontSize">10</float>
-						<int key="IBUINumberOfLines">0</int>
-						<int key="IBUILineBreakMode">0</int>
-						<reference key="IBUIFontDescription" ref="191406775"/>
-						<reference key="IBUIFont" ref="346983120"/>
-					</object>
-					<object class="IBUILabel" id="185383553">
-						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">298</int>
-						<string key="NSFrame">{{49, 280}, {177, 63}}</string>
-						<reference key="NSSuperview" ref="791280918"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">A task can include any number of projects or contexts.</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MSAxIDEAA</bytes>
-							<reference key="NSCustomColorSpace" ref="403207145"/>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">1</int>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-						<float key="IBUIMinimumFontSize">10</float>
-						<int key="IBUINumberOfLines">0</int>
-						<int key="IBUILineBreakMode">0</int>
-						<reference key="IBUIFontDescription" ref="191406775"/>
-						<reference key="IBUIFont" ref="346983120"/>
-					</object>
 					<object class="IBUIButton" id="125131458">
 						<reference key="NSNextResponder" ref="791280918"/>
 						<int key="NSvFlags">269</int>
@@ -275,7 +130,7 @@
 						<reference key="NSSuperview" ref="791280918"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView"/>
-						<object class="NSColor" key="IBUIBackgroundColor">
+						<object class="NSColor" key="IBUIBackgroundColor" id="289093231">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MCAwAA</bytes>
 						</object>
@@ -304,11 +159,25 @@
 							<int key="NSfFlags">16</int>
 						</object>
 					</object>
+					<object class="IBUIWebView" id="436488066">
+						<reference key="NSNextResponder" ref="791280918"/>
+						<int key="NSvFlags">274</int>
+						<string key="NSFrame">{{40, 20}, {240, 363}}</string>
+						<reference key="NSSuperview" ref="791280918"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="125131458"/>
+						<reference key="IBUIBackgroundColor" ref="289093231"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIAutoresizesSubviews">NO</bool>
+						<int key="IBUIContentMode">9</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
 				</object>
 				<string key="NSFrameSize">{320, 460}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="516451120"/>
+				<reference key="NSNextKeyView" ref="436488066"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">3</int>
 					<bytes key="NSWhite">MAA</bytes>
@@ -359,6 +228,14 @@
 						<reference key="destination" ref="125131458"/>
 					</object>
 					<int key="connectionID">38</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">helpContents</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="436488066"/>
+					</object>
+					<int key="connectionID">41</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchEventConnection" key="connection">
@@ -465,44 +342,20 @@
 						<reference key="object" ref="791280918"/>
 						<object class="NSMutableArray" key="children">
 							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="666484715"/>
-							<reference ref="185383553"/>
-							<reference ref="99457092"/>
-							<reference ref="516451120"/>
-							<reference ref="602818637"/>
 							<reference ref="125131458"/>
+							<reference ref="436488066"/>
 						</object>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">Help Screen View</string>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">27</int>
-						<reference key="object" ref="516451120"/>
-						<reference key="parent" ref="791280918"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">28</int>
-						<reference key="object" ref="666484715"/>
-						<reference key="parent" ref="791280918"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">29</int>
-						<reference key="object" ref="602818637"/>
-						<reference key="parent" ref="791280918"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">30</int>
-						<reference key="object" ref="99457092"/>
-						<reference key="parent" ref="791280918"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">31</int>
-						<reference key="object" ref="185383553"/>
-						<reference key="parent" ref="791280918"/>
-					</object>
-					<object class="IBObjectRecord">
 						<int key="objectID">35</int>
 						<reference key="object" ref="125131458"/>
+						<reference key="parent" ref="791280918"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">40</int>
+						<reference key="object" ref="436488066"/>
 						<reference key="parent" ref="791280918"/>
 					</object>
 				</object>
@@ -521,13 +374,9 @@
 					<string>16.CustomClassName</string>
 					<string>16.IBPluginDependency</string>
 					<string>26.IBPluginDependency</string>
-					<string>27.IBPluginDependency</string>
-					<string>28.IBPluginDependency</string>
-					<string>29.IBPluginDependency</string>
-					<string>30.IBPluginDependency</string>
-					<string>31.IBPluginDependency</string>
 					<string>35.IBPluginDependency</string>
 					<string>35.IBUIButtonInspectorSelectedStateConfigurationMetadataKey</string>
+					<string>40.IBPluginDependency</string>
 					<string>5.IBPluginDependency</string>
 					<string>6.IBPluginDependency</string>
 				</object>
@@ -544,12 +393,8 @@
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<real value="0.0"/>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				</object>
@@ -566,7 +411,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">39</int>
+			<int key="maxID">41</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -641,6 +486,7 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>accessoryView</string>
 							<string>helpCloseButton</string>
+							<string>helpContents</string>
 							<string>helpView</string>
 							<string>navItem</string>
 							<string>textView</string>
@@ -649,6 +495,7 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>UIView</string>
 							<string>UIButton</string>
+							<string>UIView</string>
 							<string>UIView</string>
 							<string>UINavigationItem</string>
 							<string>SSTextView</string>
@@ -660,6 +507,7 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>accessoryView</string>
 							<string>helpCloseButton</string>
+							<string>helpContents</string>
 							<string>helpView</string>
 							<string>navItem</string>
 							<string>textView</string>
@@ -673,6 +521,10 @@
 							<object class="IBToOneOutletInfo">
 								<string key="name">helpCloseButton</string>
 								<string key="candidateClassName">UIButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">helpContents</string>
+								<string key="candidateClassName">UIView</string>
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">helpView</string>

--- a/TaskEditViewController.xib
+++ b/TaskEditViewController.xib
@@ -120,13 +120,13 @@
 			</object>
 			<object class="IBUIView" id="791280918">
 				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">292</int>
+				<int key="NSvFlags">274</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<object class="IBUILabel" id="516451120">
 						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{47, 87}, {76, 22}}</string>
+						<int key="NSvFlags">298</int>
+						<string key="NSFrame">{{49, 87}, {76, 22}}</string>
 						<reference key="NSSuperview" ref="791280918"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="666484715"/>
@@ -163,8 +163,8 @@
 					</object>
 					<object class="IBUILabel" id="666484715">
 						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{49, 88}, {223, 63}}</string>
+						<int key="NSvFlags">298</int>
+						<string key="NSFrame">{{49, 87}, {223, 63}}</string>
 						<reference key="NSSuperview" ref="791280918"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="602818637"/>
@@ -190,7 +190,7 @@
 					</object>
 					<object class="IBUILabel" id="602818637">
 						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">292</int>
+						<int key="NSvFlags">298</int>
 						<string key="NSFrame">{{49, 173}, {76, 22}}</string>
 						<reference key="NSSuperview" ref="791280918"/>
 						<reference key="NSWindow"/>
@@ -216,7 +216,7 @@
 					</object>
 					<object class="IBUILabel" id="99457092">
 						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">292</int>
+						<int key="NSvFlags">298</int>
 						<string key="NSFrame">{{49, 173}, {222, 84}}</string>
 						<reference key="NSSuperview" ref="791280918"/>
 						<reference key="NSWindow"/>
@@ -243,11 +243,11 @@
 					</object>
 					<object class="IBUILabel" id="185383553">
 						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">292</int>
+						<int key="NSvFlags">298</int>
 						<string key="NSFrame">{{49, 280}, {177, 63}}</string>
 						<reference key="NSSuperview" ref="791280918"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="125131458"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<int key="IBUIContentMode">7</int>
@@ -270,8 +270,8 @@
 					</object>
 					<object class="IBUIButton" id="125131458">
 						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{128, 385}, {64, 28}}</string>
+						<int key="NSvFlags">269</int>
+						<string key="NSFrame">{{128, 412}, {64, 28}}</string>
 						<reference key="NSSuperview" ref="791280918"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView"/>
@@ -566,7 +566,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">38</int>
+			<int key="maxID">39</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/TaskEditViewController.xib
+++ b/TaskEditViewController.xib
@@ -49,6 +49,7 @@
 						<int key="NSvFlags">274</int>
 						<string key="NSFrame">{{0, 44}, {320, 416}}</string>
 						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView"/>
 						<object class="NSColor" key="IBUIBackgroundColor">
 							<int key="NSColorSpace">1</int>
@@ -78,6 +79,7 @@
 						<int key="NSvFlags">290</int>
 						<string key="NSFrameSize">{320, 44}</string>
 						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1035810405"/>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<object class="NSArray" key="IBUIItems">
@@ -104,6 +106,7 @@
 				</object>
 				<string key="NSFrame">{{0, 20}, {320, 460}}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="375530780"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">3</int>
@@ -515,6 +518,7 @@
 					<string>1.IBPluginDependency</string>
 					<string>14.IBPluginDependency</string>
 					<string>15.IBPluginDependency</string>
+					<string>16.CustomClassName</string>
 					<string>16.IBPluginDependency</string>
 					<string>26.IBPluginDependency</string>
 					<string>27.IBPluginDependency</string>
@@ -536,6 +540,7 @@
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>SSTextView</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -566,6 +571,14 @@
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
 				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBPartialClassDescription">
+					<string key="className">SSTextView</string>
+					<string key="superclassName">UITextView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SSTextView.h</string>
+					</object>
+				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">TaskEditViewController</string>
 					<string key="superclassName">UIViewController</string>
@@ -638,7 +651,7 @@
 							<string>UIButton</string>
 							<string>UIView</string>
 							<string>UINavigationItem</string>
-							<string>UITextView</string>
+							<string>SSTextView</string>
 						</object>
 					</object>
 					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
@@ -671,7 +684,7 @@
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">textView</string>
-								<string key="candidateClassName">UITextView</string>
+								<string key="candidateClassName">SSTextView</string>
 							</object>
 						</object>
 					</object>

--- a/TaskEditViewController.xib
+++ b/TaskEditViewController.xib
@@ -123,6 +123,23 @@
 				<int key="NSvFlags">274</int>
 				<object class="NSMutableArray" key="NSSubviews">
 					<bool key="EncodedWithXMLCoder">YES</bool>
+					<object class="IBUIWebView" id="1016483019">
+						<reference key="NSNextResponder" ref="791280918"/>
+						<int key="NSvFlags">274</int>
+						<string key="NSFrame">{{30, 20}, {260, 363}}</string>
+						<reference key="NSSuperview" ref="791280918"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="125131458"/>
+						<object class="NSColor" key="IBUIBackgroundColor" id="26781663">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MCAwAA</bytes>
+						</object>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIAutoresizesSubviews">NO</bool>
+						<int key="IBUIContentMode">9</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
 					<object class="IBUIButton" id="125131458">
 						<reference key="NSNextResponder" ref="791280918"/>
 						<int key="NSvFlags">269</int>
@@ -130,10 +147,7 @@
 						<reference key="NSSuperview" ref="791280918"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView"/>
-						<object class="NSColor" key="IBUIBackgroundColor" id="289093231">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MCAwAA</bytes>
-						</object>
+						<reference key="IBUIBackgroundColor" ref="26781663"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
@@ -159,25 +173,11 @@
 							<int key="NSfFlags">16</int>
 						</object>
 					</object>
-					<object class="IBUIWebView" id="436488066">
-						<reference key="NSNextResponder" ref="791280918"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrame">{{40, 20}, {240, 363}}</string>
-						<reference key="NSSuperview" ref="791280918"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="125131458"/>
-						<reference key="IBUIBackgroundColor" ref="289093231"/>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIAutoresizesSubviews">NO</bool>
-						<int key="IBUIContentMode">9</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-					</object>
 				</object>
 				<string key="NSFrameSize">{320, 460}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="436488066"/>
+				<reference key="NSNextKeyView" ref="1016483019"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">3</int>
 					<bytes key="NSWhite">MAA</bytes>
@@ -233,7 +233,7 @@
 					<object class="IBCocoaTouchOutletConnection" key="connection">
 						<string key="label">helpContents</string>
 						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="436488066"/>
+						<reference key="destination" ref="1016483019"/>
 					</object>
 					<int key="connectionID">41</int>
 				</object>
@@ -343,7 +343,7 @@
 						<object class="NSMutableArray" key="children">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<reference ref="125131458"/>
-							<reference ref="436488066"/>
+							<reference ref="1016483019"/>
 						</object>
 						<reference key="parent" ref="0"/>
 						<string key="objectName">Help Screen View</string>
@@ -355,7 +355,7 @@
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">40</int>
-						<reference key="object" ref="436488066"/>
+						<reference key="object" ref="1016483019"/>
 						<reference key="parent" ref="791280918"/>
 					</object>
 				</object>

--- a/todo.txt-touch-ios.xcodeproj/project.pbxproj
+++ b/todo.txt-touch-ios.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		8887496D13F3715400871E49 /* ActionSheetPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 8887496C13F3715400871E49 /* ActionSheetPicker.m */; };
 		88A91724146614920075B886 /* DropboxSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88A91723146614920075B886 /* DropboxSDK.framework */; };
 		88AAFC631419CB960062BBF6 /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 88AAFC621419CB960062BBF6 /* Icon@2x.png */; };
+		88F043E2148879C1007C32DA /* SSTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 88334817146F5D4F009CBDE9 /* SSTextView.m */; };
 		88F1AB2A1412D5F100AB3D18 /* LoginScreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 88F1AB281412D5F100AB3D18 /* LoginScreenViewController.m */; };
 		88F1AB2B1412D5F100AB3D18 /* LoginScreenViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 88F1AB291412D5F100AB3D18 /* LoginScreenViewController.xib */; };
 		88F1AB2E1412E20D00AB3D18 /* todotxt_touch_256.png in Resources */ = {isa = PBXBuildFile; fileRef = 88F1AB2D1412E20D00AB3D18 /* todotxt_touch_256.png */; };
@@ -200,6 +201,8 @@
 		8831984913EBC59E00EC5BC3 /* TaskBagFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TaskBagFactory.m; path = Classes/TaskBagFactory.m; sourceTree = "<group>"; };
 		8831984B13EBC62C00EC5BC3 /* TaskBagImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TaskBagImpl.h; path = Classes/TaskBagImpl.h; sourceTree = "<group>"; };
 		8831984C13EBC62C00EC5BC3 /* TaskBagImpl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TaskBagImpl.m; path = Classes/TaskBagImpl.m; sourceTree = "<group>"; };
+		88334816146F5D4F009CBDE9 /* SSTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSTextView.h; sourceTree = "<group>"; };
+		88334817146F5D4F009CBDE9 /* SSTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSTextView.m; sourceTree = "<group>"; };
 		883E42FC13EB7BDC002FEBCC /* TaskBag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TaskBag.h; path = Classes/TaskBag.h; sourceTree = "<group>"; };
 		883E42FE13EB7E66002FEBCC /* LocalTaskRepository.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LocalTaskRepository.h; path = Classes/LocalTaskRepository.h; sourceTree = "<group>"; };
 		883E42FF13EB8395002FEBCC /* LocalFileTaskRepository.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LocalFileTaskRepository.h; path = Classes/LocalFileTaskRepository.h; sourceTree = "<group>"; };
@@ -524,6 +527,8 @@
 				888065B61401A51C0036DE2A /* Network.m */,
 				F4595BE41453DC48000FB9F6 /* NSMutableAttributedString+TodoTxt.h */,
 				F4595BE51453DC48000FB9F6 /* NSMutableAttributedString+TodoTxt.m */,
+				88334816146F5D4F009CBDE9 /* SSTextView.h */,
+				88334817146F5D4F009CBDE9 /* SSTextView.m */,
 			);
 			name = Util;
 			sourceTree = "<group>";
@@ -648,6 +653,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88F043E2148879C1007C32DA /* SSTextView.m in Sources */,
 				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
 				1D3623260D0F684500981E51 /* todo_txt_touch_iosAppDelegate.m in Sources */,
 				28D7ACF80DDB3853001CB0EB /* todo_txt_touch_iosViewController.m in Sources */,

--- a/todo_txt_touch_iosViewController.xib
+++ b/todo_txt_touch_iosViewController.xib
@@ -18,7 +18,6 @@
 			<string>IBUIToolbar</string>
 			<string>IBUISearchBar</string>
 			<string>IBUILabel</string>
-			<string>IBUISegmentedControl</string>
 			<string>IBUITableView</string>
 			<string>IBUIView</string>
 		</object>
@@ -87,52 +86,10 @@
 					<object class="IBUIToolbar" id="940181822">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">266</int>
-						<object class="NSMutableArray" key="NSSubviews">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBUISegmentedControl" id="196083117">
-								<reference key="NSNextResponder" ref="940181822"/>
-								<int key="NSvFlags">256</int>
-								<string key="NSFrame">{{104, 8}, {112, 30}}</string>
-								<reference key="NSSuperview" ref="940181822"/>
-								<reference key="NSWindow"/>
-								<bool key="IBUIOpaque">NO</bool>
-								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-								<int key="IBUIContentHorizontalAlignment">0</int>
-								<int key="IBUIContentVerticalAlignment">0</int>
-								<int key="IBSegmentControlStyle">2</int>
-								<int key="IBNumberOfSegments">2</int>
-								<object class="NSArray" key="IBSegmentTitles">
-									<bool key="EncodedWithXMLCoder">YES</bool>
-									<string>Filter</string>
-									<string>Sort</string>
-								</object>
-								<object class="NSMutableArray" key="IBSegmentWidths">
-									<bool key="EncodedWithXMLCoder">YES</bool>
-									<real value="0.0"/>
-									<real value="0.0"/>
-								</object>
-								<object class="NSMutableArray" key="IBSegmentEnabledStates">
-									<bool key="EncodedWithXMLCoder">YES</bool>
-									<boolean value="YES"/>
-									<boolean value="YES"/>
-								</object>
-								<object class="NSMutableArray" key="IBSegmentContentOffsets">
-									<bool key="EncodedWithXMLCoder">YES</bool>
-									<string>{0, 0}</string>
-									<string>{0, 0}</string>
-								</object>
-								<object class="NSMutableArray" key="IBSegmentImages">
-									<bool key="EncodedWithXMLCoder">YES</bool>
-									<object class="NSNull" id="4"/>
-									<reference ref="4"/>
-								</object>
-								<bool key="IBMomentary">YES</bool>
-							</object>
-						</object>
 						<string key="NSFrame">{{0, 372}, {320, 44}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="196083117"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -142,16 +99,6 @@
 								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 								<reference key="IBUIToolbar" ref="940181822"/>
 								<int key="IBUISystemItemIdentifier">13</int>
-							</object>
-							<object class="IBUIBarButtonItem" id="472002315">
-								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-								<reference key="IBUIToolbar" ref="940181822"/>
-								<int key="IBUISystemItemIdentifier">5</int>
-							</object>
-							<object class="IBUIBarButtonItem" id="912675188">
-								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-								<reference key="IBUICustomView" ref="196083117"/>
-								<reference key="IBUIToolbar" ref="940181822"/>
 							</object>
 							<object class="IBUIBarButtonItem" id="569659191">
 								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -231,6 +178,7 @@
 						<string key="NSFrame">{{14, 104}, {293, 33}}</string>
 						<reference key="NSSuperview" ref="1013477715"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<int key="IBUIContentMode">4</int>
@@ -327,15 +275,6 @@
 						<reference key="destination" ref="372490531"/>
 					</object>
 					<int key="connectionID">48</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">segmentControlPressed:</string>
-						<reference key="source" ref="196083117"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">13</int>
-					</object>
-					<int key="connectionID">47</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchEventConnection" key="connection">
@@ -441,9 +380,7 @@
 						<object class="NSMutableArray" key="children">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<reference ref="1069796159"/>
-							<reference ref="472002315"/>
 							<reference ref="569659191"/>
-							<reference ref="912675188"/>
 							<reference ref="1071900226"/>
 						</object>
 						<reference key="parent" ref="774585933"/>
@@ -451,25 +388,6 @@
 					<object class="IBObjectRecord">
 						<int key="objectID">20</int>
 						<reference key="object" ref="1069796159"/>
-						<reference key="parent" ref="940181822"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">31</int>
-						<reference key="object" ref="912675188"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="196083117"/>
-						</object>
-						<reference key="parent" ref="940181822"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">30</int>
-						<reference key="object" ref="196083117"/>
-						<reference key="parent" ref="912675188"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">34</int>
-						<reference key="object" ref="472002315"/>
 						<reference key="parent" ref="940181822"/>
 					</object>
 					<object class="IBObjectRecord">
@@ -526,9 +444,6 @@
 					<string>17.IBPluginDependency</string>
 					<string>20.IBPluginDependency</string>
 					<string>29.IBPluginDependency</string>
-					<string>30.IBPluginDependency</string>
-					<string>31.IBPluginDependency</string>
-					<string>34.IBPluginDependency</string>
 					<string>43.IBPluginDependency</string>
 					<string>50.IBPluginDependency</string>
 					<string>51.IBPluginDependency</string>
@@ -544,9 +459,6 @@
 					<string>todo_txt_touch_iosViewController</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>UIResponder</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -574,7 +486,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">62</int>
+			<int key="maxID">64</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -606,8 +518,8 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>addButtonPressed:</string>
-							<string>segmentControlPressed:</string>
 							<string>settingsButtonPressed:</string>
+							<string>sortButtonPressed:</string>
 							<string>syncButtonPressed:</string>
 						</object>
 						<object class="NSMutableArray" key="dict.values">
@@ -623,8 +535,8 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>addButtonPressed:</string>
-							<string>segmentControlPressed:</string>
 							<string>settingsButtonPressed:</string>
+							<string>sortButtonPressed:</string>
 							<string>syncButtonPressed:</string>
 						</object>
 						<object class="NSMutableArray" key="dict.values">
@@ -634,11 +546,11 @@
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
-								<string key="name">segmentControlPressed:</string>
+								<string key="name">settingsButtonPressed:</string>
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
-								<string key="name">settingsButtonPressed:</string>
+								<string key="name">sortButtonPressed:</string>
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
@@ -688,10 +600,6 @@
 		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<real value="1280" key="NS.object.0"/>
-		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
 			<integer value="3100" key="NS.object.0"/>


### PR DESCRIPTION
The screen that pops up when you press help on the edit screen was messed up in landscape mode. This code should fix that. I also made sure every popover on iPad automatically goes away when the orientation changes, otherwise they look weird.
