### PR TITLE
implemented changes to support new revision support in Dropbox API v1.0

### DIFF
--- a/Classes/DropboxRemoteClient.h
+++ b/Classes/DropboxRemoteClient.h
@@ -50,11 +50,14 @@
 #import <Foundation/Foundation.h>
 #import "RemoteClient.h"
 #import <DropboxSDK/DropboxSDK.h>
+#import "DropboxTodoDownloader.h"
+#import "DropboxTodoUploader.h"
 #import "TestFlight.h"
 
 @interface DropboxRemoteClient : NSObject<RemoteClient> {
-    DBRestClient *restClient;
 	id<RemoteClientDelegate> delegate;
+	DropboxTodoDownloader *downloader;
+	DropboxTodoUploader *uploader;
 }
 
 @property (nonatomic, assign) id<RemoteClientDelegate> delegate;
@@ -65,7 +68,11 @@
 - (void) presentLoginControllerFromController:(UIViewController*)parentViewController;
 - (void) pullTodo;
 - (void) pushTodo:(NSString*)path;
+- (void) pushTodoForce:(NSString*)path;
 - (BOOL) isAvailable;
 - (BOOL) handleOpenURL:(NSURL *)url;
+
++ (NSString*) todoTxtTmpFile;
++ (NSString*) todoTxtRemoteFile;
 
 @end

--- a/Classes/DropboxTodoDownloader.h
+++ b/Classes/DropboxTodoDownloader.h
@@ -47,50 +47,21 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#import <UIKit/UIKit.h>
-#import "TaskBag.h"
-#import "RemoteClientManager.h"
+
+#import <Foundation/Foundation.h>
+#import "RemoteClient.h"
+#import <DropboxSDK/DropboxSDK.h>
 #import "TestFlight.h"
 
-#define kTodoChangedNotification @"kTodoChangedNotification"
-
-@class todo_txt_touch_iosViewController;
-
-@interface todo_txt_touch_iosAppDelegate : NSObject <UIApplicationDelegate, RemoteClientDelegate, UIActionSheetDelegate, UIAlertViewDelegate> {
-    UIWindow *window;
-    todo_txt_touch_iosViewController *viewController;
-	UINavigationController *navigationController;
-    id <TaskBag> taskBag;
-	RemoteClientManager *remoteClientManager;
-    id lastClickedButton; //Anchor holder for the Popover in iPad
+@interface DropboxTodoDownloader : NSObject {
+	id<RemoteClient> remoteClient;
+	DBRestClient *restClient;
+	NSString *rev;
 }
 
-@property (nonatomic, retain) IBOutlet UIWindow *window;
-@property (nonatomic, retain) IBOutlet todo_txt_touch_iosViewController *viewController;
-@property (nonatomic, retain) IBOutlet UINavigationController *navigationController;
-@property (nonatomic, readonly) id <TaskBag> taskBag;
-@property (nonatomic, readonly) RemoteClientManager *remoteClientManager;
-@property (nonatomic, retain) id lastClickedButton; 
+@property (nonatomic, assign) id<RemoteClient> remoteClient;
+@property (nonatomic, readonly) NSString *rev;
 
-- (void) syncClient;
-- (void) syncClientWithPrompt;
-- (void) syncClientForceChoice:(BOOL)forceChoice;
-- (void) pushToRemote;
-- (void) pullFromRemote;
-- (BOOL) isOfflineMode;
-- (BOOL) setOfflineMode:(BOOL)goOffline;
-- (void) logout;
-
-+ (todo_txt_touch_iosAppDelegate*) sharedDelegate;
-+ (id<TaskBag>) sharedTaskBag;
-+ (RemoteClientManager*) sharedRemoteClientManager;
-+ (void) syncClient;
-+ (void) syncClientWithPrompt;
-+ (void) pushToRemote;
-+ (void) pullFromRemote;
-+ (BOOL) isOfflineMode;
-+ (BOOL) setOfflineMode:(BOOL)goOffline;
-+ (void) logout;
+- (void) pullTodo;
 
 @end
-

--- a/Classes/DropboxTodoDownloader.m
+++ b/Classes/DropboxTodoDownloader.m
@@ -1,0 +1,120 @@
+/**
+ *
+ * Todo.txt-Touch-iOS/Classes/todo_txt_touch_iosAppDelegate.h
+ *
+ * Copyright (c) 2009-2011 Gina Trapani, Shawn McGuire
+ *
+ * LICENSE:
+ *
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file (http://todotxt.com).
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
+ * @author Shawn McGuire <mcguiresm[at]gmail[dot]com> 
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2011 Gina Trapani, Shawn McGuire
+ *
+ *
+ * Copyright (c) 2011 Gina Trapani and contributors, http://todotxt.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "DropboxTodoDownloader.h"
+#import "DropboxRemoteClient.h"
+
+@interface DropboxTodoDownloader () <DBRestClientDelegate>
+@end
+
+@implementation DropboxTodoDownloader 
+
+@synthesize remoteClient, rev;
+
+- (DBRestClient*)restClient {
+    if (restClient == nil) {
+    	restClient = [[DBRestClient alloc] initWithSession:[DBSession sharedSession]];
+    	restClient.delegate = self;
+    }
+    return restClient;
+}
+ 
+- (void) pullTodo {
+	
+	// First call loadMetadata to get the current rev
+	// then, call loadFile with that rev
+	// don't save rev until we successfully loaded the file
+	[self.restClient loadMetadata:[DropboxRemoteClient todoTxtRemoteFile]];
+}
+
+#pragma mark -
+#pragma mark DBRestClientDelegate methods
+
+- (void)restClient:(DBRestClient*)client loadedMetadata:(DBMetadata*)metadata {
+	// we loaded the latest metadata for the todo file. Now we can pull it
+	rev = [metadata.rev retain];	
+		
+	[self.restClient loadFile:[DropboxRemoteClient todoTxtRemoteFile]
+						atRev:rev 
+					 intoPath:[DropboxRemoteClient todoTxtTmpFile]];	
+}
+
+- (void)restClient:(DBRestClient*)client loadMetadataFailedWithError:(NSError*)error {
+	// there was no metadata for the todo file, meaning it does not exist
+	// so there is nothing to load
+	// call RemoteClientDelegate method
+	if (self.remoteClient.delegate && [self.remoteClient.delegate respondsToSelector:@selector(remoteClient:loadedFile:)]) {
+		[self.remoteClient.delegate remoteClient:self.remoteClient loadedFile:nil];
+	}
+}
+
+- (void)restClient:(DBRestClient*)client loadedFile:(NSString*)destPath {
+	// save off the downloaded file's rev
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	[defaults setValue:rev forKey:@"dropbox_last_rev"];
+	
+	// call RemoteClientDelegate method
+	if (self.remoteClient.delegate && [self.remoteClient.delegate respondsToSelector:@selector(remoteClient:loadedFile:)]) {
+		[self.remoteClient.delegate remoteClient:self.remoteClient loadedFile:destPath];
+	}
+}
+
+- (void)restClient:(DBRestClient*)client loadFileFailedWithError:(NSError*)error {
+	if (self.remoteClient.delegate && [self.remoteClient.delegate respondsToSelector:@selector(remoteClient:loadFileFailedWithError:)]) {
+		[self.remoteClient.delegate remoteClient:self.remoteClient loadFileFailedWithError:error];
+	}
+}
+
+- (void) dealloc {
+	[rev release];
+	[restClient release];
+	[super dealloc];
+}
+
+@end

--- a/Classes/DropboxTodoUploader.h
+++ b/Classes/DropboxTodoUploader.h
@@ -47,50 +47,25 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#import <UIKit/UIKit.h>
-#import "TaskBag.h"
-#import "RemoteClientManager.h"
+
+#import <Foundation/Foundation.h>
+#import "RemoteClient.h"
+#import <DropboxSDK/DropboxSDK.h>
 #import "TestFlight.h"
 
-#define kTodoChangedNotification @"kTodoChangedNotification"
-
-@class todo_txt_touch_iosViewController;
-
-@interface todo_txt_touch_iosAppDelegate : NSObject <UIApplicationDelegate, RemoteClientDelegate, UIActionSheetDelegate, UIAlertViewDelegate> {
-    UIWindow *window;
-    todo_txt_touch_iosViewController *viewController;
-	UINavigationController *navigationController;
-    id <TaskBag> taskBag;
-	RemoteClientManager *remoteClientManager;
-    id lastClickedButton; //Anchor holder for the Popover in iPad
+@interface DropboxTodoUploader : NSObject {
+	id<RemoteClient> remoteClient;
+	DBRestClient *restClient;
+	NSString *rev;
+	NSString *localFile;
+	BOOL force;
 }
 
-@property (nonatomic, retain) IBOutlet UIWindow *window;
-@property (nonatomic, retain) IBOutlet todo_txt_touch_iosViewController *viewController;
-@property (nonatomic, retain) IBOutlet UINavigationController *navigationController;
-@property (nonatomic, readonly) id <TaskBag> taskBag;
-@property (nonatomic, readonly) RemoteClientManager *remoteClientManager;
-@property (nonatomic, retain) id lastClickedButton; 
+@property (nonatomic, assign) id<RemoteClient> remoteClient;
+@property (nonatomic, readonly) NSString *rev;
+@property (nonatomic, retain) NSString *localFile;
+@property (nonatomic, assign) BOOL force;
 
-- (void) syncClient;
-- (void) syncClientWithPrompt;
-- (void) syncClientForceChoice:(BOOL)forceChoice;
-- (void) pushToRemote;
-- (void) pullFromRemote;
-- (BOOL) isOfflineMode;
-- (BOOL) setOfflineMode:(BOOL)goOffline;
-- (void) logout;
-
-+ (todo_txt_touch_iosAppDelegate*) sharedDelegate;
-+ (id<TaskBag>) sharedTaskBag;
-+ (RemoteClientManager*) sharedRemoteClientManager;
-+ (void) syncClient;
-+ (void) syncClientWithPrompt;
-+ (void) pushToRemote;
-+ (void) pullFromRemote;
-+ (BOOL) isOfflineMode;
-+ (BOOL) setOfflineMode:(BOOL)goOffline;
-+ (void) logout;
+- (void) pushTodo;
 
 @end
-

--- a/Classes/DropboxTodoUploader.m
+++ b/Classes/DropboxTodoUploader.m
@@ -1,0 +1,138 @@
+/**
+ *
+ * Todo.txt-Touch-iOS/Classes/todo_txt_touch_iosAppDelegate.h
+ *
+ * Copyright (c) 2009-2011 Gina Trapani, Shawn McGuire
+ *
+ * LICENSE:
+ *
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file (http://todotxt.com).
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
+ * @author Shawn McGuire <mcguiresm[at]gmail[dot]com> 
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2011 Gina Trapani, Shawn McGuire
+ *
+ *
+ * Copyright (c) 2011 Gina Trapani and contributors, http://todotxt.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "DropboxTodoUploader.h"
+#import "DropboxRemoteClient.h"
+
+@interface DropboxTodoUploader () <DBRestClientDelegate>
+@end
+
+@implementation DropboxTodoUploader 
+
+@synthesize remoteClient, rev, localFile, force;
+
+- (DBRestClient*)restClient {
+    if (restClient == nil) {
+    	restClient = [[DBRestClient alloc] initWithSession:[DBSession sharedSession]];
+    	restClient.delegate = self;
+    }
+    return restClient;
+}
+ 
+- (void) pushTodo {
+	
+	// First call loadMetadata to get the current rev
+	// then, call uploadFile with that rev
+	[self.restClient loadMetadata:[DropboxRemoteClient todoTxtRemoteFile]];
+}
+
+#pragma mark -
+#pragma mark DBRestClientDelegate methods
+
+- (void)restClient:(DBRestClient*)client loadedMetadata:(DBMetadata*)metadata {
+	// we loaded the latest metadata for the todo file. Now we can push it
+	rev = [metadata.rev retain];	
+
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	NSString *remotePath = [defaults stringForKey:@"file_location_preference"];
+	NSString *lastRev = [defaults stringForKey:@"dropbox_last_rev"];
+	
+	if (!force && ![rev isEqualToString:lastRev]) {
+		// Conflict! Call RemoteClientDelegate method
+		if (self.remoteClient.delegate && [self.remoteClient.delegate respondsToSelector:@selector(remoteClient:uploadFileFailedWithConflict:)]) {
+			[self.remoteClient.delegate remoteClient:self.remoteClient uploadFileFailedWithConflict:remotePath];
+		}
+		return;
+	}
+	
+	[self.restClient uploadFile:@"todo.txt" toPath:remotePath withParentRev:rev fromPath:localFile];
+}
+
+- (void)restClient:(DBRestClient*)client loadMetadataFailedWithError:(NSError*)error {
+	// there was no metadata for the todo file, meaning it does not exist
+	// so we can upload with a nil rev
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	NSString *remotePath = [defaults stringForKey:@"file_location_preference"];
+	[self.restClient uploadFile:@"todo.txt" toPath:remotePath withParentRev:nil fromPath:localFile];
+}
+
+- (void)restClient:(DBRestClient*)client uploadedFile:(NSString*)destPath from:(NSString*)srcPath 
+		  metadata:(DBMetadata *)metadata {	
+	rev = [metadata.rev retain];	
+
+	if (![metadata.path isEqualToString:destPath]) {
+		// If the uploaded remote path does not match our expected remotePath, 
+		// then a conflict occurred and we should announce the conflict to the user.
+		return;
+	}
+	
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	[defaults setValue:rev forKey:@"dropbox_last_rev"];
+
+	// call RemoteClientDelegate method
+	if (self.remoteClient.delegate && [self.remoteClient.delegate respondsToSelector:@selector(remoteClient:uploadedFile:)]) {
+		[self.remoteClient.delegate remoteClient:self.remoteClient uploadedFile:destPath];
+	}
+}
+
+- (void)restClient:(DBRestClient*)client uploadFileFailedWithError:(NSError*)error {
+	// call RemoteClientDelegate method
+	if (self.remoteClient.delegate && [self.remoteClient.delegate respondsToSelector:@selector(remoteClient:uploadFileFailedWithError:)]) {
+		[self.remoteClient.delegate remoteClient:self.remoteClient uploadFileFailedWithError:error];
+	}
+}
+
+- (void) dealloc {
+	[rev release];
+	[restClient release];
+	[localFile release];
+	[super dealloc];
+}
+
+@end

--- a/Classes/RemoteClient.h
+++ b/Classes/RemoteClient.h
@@ -65,6 +65,7 @@ typedef enum {
 - (void) presentLoginControllerFromController:(UIViewController*)parentViewController;
 - (void) pullTodo;
 - (void) pushTodo:(NSString*)path;
+- (void) pushTodoForce:(NSString*)path;
 - (BOOL) isAvailable;
 - (BOOL) handleOpenURL:(NSURL *)url;
 
@@ -76,7 +77,10 @@ typedef enum {
 @protocol RemoteClientDelegate <NSObject>
 
 - (void)remoteClient:(id<RemoteClient>)client loadedFile:(NSString*)destPath;
+- (void)remoteClient:(id<RemoteClient>)client loadFileFailedWithError:(NSError*)error;
 - (void)remoteClient:(id<RemoteClient>)client uploadedFile:(NSString*)destPath;
+- (void)remoteClient:(id<RemoteClient>)client uploadFileFailedWithError:(NSError*)error;
+- (void)remoteClient:(id<RemoteClient>)client uploadFileFailedWithConflict:(NSString*)destPath;
 - (void)remoteClient:(id<RemoteClient>)client loginControllerDidLogin:(BOOL)success;
 
 

--- a/Classes/TaskViewController.m
+++ b/Classes/TaskViewController.m
@@ -99,12 +99,21 @@ char *completed_buttons[] = { "Undo Complete", "Delete" };
 - (void)viewWillAppear:(BOOL)animated {
     // Update the view with current data before it is displayed.
     [super viewWillAppear:animated];
-    
+	
+ 	[[NSNotificationCenter defaultCenter] addObserver:self 
+											 selector:@selector(reloadViewData) 
+												 name:kTodoChangedNotification 
+											   object:nil];
+   
 	[self reloadViewData];
 	
     self.title = @"Task Details";
 }
 
+- (void) viewWillDisappear:(BOOL)animated {
+	[super viewWillDisappear:animated];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];	
+}
 
 #pragma mark -
 #pragma mark Table view data source

--- a/Classes/todo_txt_touch_iosAppDelegate.m
+++ b/Classes/todo_txt_touch_iosAppDelegate.m
@@ -110,6 +110,16 @@
 	return [[todo_txt_touch_iosAppDelegate sharedDelegate] logout];
 }
 
++ (BOOL) needToPush {
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    return [defaults boolForKey:@"need_to_push"];
+}
+
++ (void) setNeedToPush:(BOOL)needToPush {
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setBool:needToPush forKey:@"need_to_push"];
+}
+
 - (void) presentLoginController {
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
         navigationController.viewControllers = [NSArray arrayWithObject:[[[iPadLoginScreenViewController alloc] init] autorelease]];
@@ -218,7 +228,7 @@
 }
 
 - (void) syncClientForceChoice:(BOOL)forceChoice {
-	if ([self isOfflineMode] || forceChoice) {
+	if ([self isOfflineMode] || forceChoice || [todo_txt_touch_iosAppDelegate needToPush]) {
 		if (![remoteClientManager.currentClient isAvailable]) {
 			// TODO: toast?
 			[self setOfflineMode:YES];
@@ -253,7 +263,9 @@
 	} 
 }
 
-- (void) pushToRemote {
+- (void) pushToRemoteForce:(BOOL)force {
+	[todo_txt_touch_iosAppDelegate setNeedToPush:NO];
+	
 	if ([self isOfflineMode]) {
 		return;
 	}
@@ -265,13 +277,26 @@
 		[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
 		// We probably shouldn't be assuming LocalFileTaskRepository here, 
 		// but that is what the Android app does, so why not?
-		[remoteClientManager.currentClient pushTodo:[LocalFileTaskRepository filename]];
+		NSString *path = [LocalFileTaskRepository filename];
+		
+		if (force) {
+			[remoteClientManager.currentClient pushTodoForce:path];
+		} else {
+			[remoteClientManager.currentClient pushTodo:path];
+		}
+		
 		// pushTodo is asynchronous. When it returns, it will call
 		// the delegate method 'uploadedFile'
 	}	
 }
 
+- (void) pushToRemote {
+	[self pushToRemoteForce:NO];
+}
+
 - (void) pullFromRemote {
+	[todo_txt_touch_iosAppDelegate setNeedToPush:NO];
+	
 	if ([self isOfflineMode]) {
 		return;
 	}
@@ -318,8 +343,70 @@
 	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];	
 }
 
+- (void) remoteClient:(id<RemoteClient>)client loadFileFailedWithError:(NSError *)error {
+	NSLog(@"Error downloading todo file: %@", error);
+	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];	
+	
+	if (error.code == 404) {
+		// ignore missing file. They may not have created one yet.
+		return;
+	}
+	
+	UIAlertView *alert =
+	[[UIAlertView alloc] initWithTitle: @"Error"
+							   message: @"There was an error downloading the todo.txt file."
+							  delegate: nil
+					 cancelButtonTitle: @"OK"
+					 otherButtonTitles: nil];
+    [alert show];
+    [alert release];
+}
+
 - (void)remoteClient:(id<RemoteClient>)client uploadedFile:(NSString*)destPath {
 	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+}
+
+- (void) remoteClient:(id<RemoteClient>)client uploadFileFailedWithError:(NSError *)error {
+	NSLog(@"Error uploading todo file: %@", error);
+	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];	
+	
+	UIAlertView *alert =
+	[[UIAlertView alloc] initWithTitle: @"Error"
+							   message: @"There was an error uploading the todo.txt file."
+							  delegate: nil
+					 cancelButtonTitle: @"OK"
+					 otherButtonTitles: nil];
+    [alert show];
+    [alert release];
+	
+	//remember the error, so that next time we press the sync button,
+	// we prompt the user to pull or push
+	[todo_txt_touch_iosAppDelegate setNeedToPush:YES];
+}
+
+- (void)remoteClient:(id<RemoteClient>)client uploadFileFailedWithConflict:(NSString*)destPath {
+	// alert user to the conflict and ask if he wants to force push or pull
+	NSLog(@"Upload conflict");
+	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];	
+	
+	UIAlertView *alert =
+	[[UIAlertView alloc] initWithTitle: @"Merge Conflict"
+							   message: @"There is a newer version of the todo file on the remote server. Do you want to upload your local changes, or download the remote version?"
+							  delegate: self
+					 cancelButtonTitle: @"Cancel"
+					 otherButtonTitles: @"Upload Changes", @"Download to device", nil];
+    [alert show];
+    [alert release];
+}
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
+	if (buttonIndex == [alertView firstOtherButtonIndex]) {
+		[self pushToRemoteForce:YES];
+	} else if (buttonIndex == [alertView firstOtherButtonIndex] + 1){
+		[self pullFromRemote];
+	} else { //cancel
+		[todo_txt_touch_iosAppDelegate setNeedToPush:YES];
+	}
 }
 
 - (void)remoteClient:(id<RemoteClient>)client loginControllerDidLogin:(BOOL)success {

--- a/todo.txt-touch-ios.xcodeproj/project.pbxproj
+++ b/todo.txt-touch-ios.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		883E430113EB8395002FEBCC /* LocalFileTaskRepository.m in Sources */ = {isa = PBXBuildFile; fileRef = 883E430013EB8395002FEBCC /* LocalFileTaskRepository.m */; };
 		8858D0BA13EA89C50083FA44 /* Priority.m in Sources */ = {isa = PBXBuildFile; fileRef = 8858D0B713EA89C50083FA44 /* Priority.m */; };
 		8858D0BB13EA89C50083FA44 /* Task.m in Sources */ = {isa = PBXBuildFile; fileRef = 8858D0B913EA89C50083FA44 /* Task.m */; };
+		8878944014954AE4000AC39C /* DropboxTodoDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 8878943F14954AE4000AC39C /* DropboxTodoDownloader.m */; };
+		887894441495AEC7000AC39C /* DropboxTodoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 887894431495AEC7000AC39C /* DropboxTodoUploader.m */; };
 		888065951401898E0036DE2A /* RemoteClientManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 888065941401898E0036DE2A /* RemoteClientManager.m */; };
 		88806599140191A30036DE2A /* DropboxRemoteClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 88806598140191A30036DE2A /* DropboxRemoteClient.m */; };
 		888065AE14019D3C0036DE2A /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 888065AD14019D3C0036DE2A /* CFNetwork.framework */; };
@@ -214,6 +216,10 @@
 		8858D0B713EA89C50083FA44 /* Priority.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Priority.m; path = Classes/Priority.m; sourceTree = "<group>"; };
 		8858D0B813EA89C50083FA44 /* Task.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Task.h; path = Classes/Task.h; sourceTree = "<group>"; };
 		8858D0B913EA89C50083FA44 /* Task.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Task.m; path = Classes/Task.m; sourceTree = "<group>"; };
+		8878943E14954AE4000AC39C /* DropboxTodoDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DropboxTodoDownloader.h; sourceTree = "<group>"; };
+		8878943F14954AE4000AC39C /* DropboxTodoDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DropboxTodoDownloader.m; sourceTree = "<group>"; };
+		887894421495AEC7000AC39C /* DropboxTodoUploader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DropboxTodoUploader.h; sourceTree = "<group>"; };
+		887894431495AEC7000AC39C /* DropboxTodoUploader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DropboxTodoUploader.m; sourceTree = "<group>"; };
 		888065931401898E0036DE2A /* RemoteClientManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteClientManager.h; sourceTree = "<group>"; };
 		888065941401898E0036DE2A /* RemoteClientManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RemoteClientManager.m; sourceTree = "<group>"; };
 		88806597140191A30036DE2A /* DropboxRemoteClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DropboxRemoteClient.h; sourceTree = "<group>"; };
@@ -553,6 +559,10 @@
 				88A91726146643B70075B886 /* DropboxApiKey.h */,
 				88806597140191A30036DE2A /* DropboxRemoteClient.h */,
 				88806598140191A30036DE2A /* DropboxRemoteClient.m */,
+				8878943E14954AE4000AC39C /* DropboxTodoDownloader.h */,
+				8878943F14954AE4000AC39C /* DropboxTodoDownloader.m */,
+				887894421495AEC7000AC39C /* DropboxTodoUploader.h */,
+				887894431495AEC7000AC39C /* DropboxTodoUploader.m */,
 				888065931401898E0036DE2A /* RemoteClientManager.h */,
 				888065941401898E0036DE2A /* RemoteClientManager.m */,
 			);
@@ -713,6 +723,8 @@
 				F4564BF214718A5800DF207C /* FlexiIPhonePortraitCell.m in Sources */,
 				F4564BF314718A5800DF207C /* FlexiTaskCellFactory.m in Sources */,
 				0F4F00611491A91900DBF796 /* TaskViewCell.m in Sources */,
+				8878944014954AE4000AC39C /* DropboxTodoDownloader.m in Sources */,
+				887894441495AEC7000AC39C /* DropboxTodoUploader.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Alright. So, Dropbox really doesn't want people to accidentally overwrite their files (which is a good thing). If you call uploadFile and pass nil in the parentRev parameter, a new file will be created: 'todo (1).txt'. If you pass a parentRev that is not the latest revision of the file, a different file is created: 'todo (Joe User's conflicted copy).txt'. In order to overwrite the existing file, we have to pass the current revision number in the parentRev parameter.

So here's what I had to do to get this to work:

First, before downloading we check the latest revision of the todo.txt file on dropbox. Then, we download that revision of the file and save off the revision number. We have to do it in that order because there is no way to get the revision number after downloading the file. Otherwise, if someone changed the file from the desktop or another app between our download and metadata request we would get a different revision number.

Now, when we get ready to upload we request the metadata again and compare the latest revision number to our saved value. If they match, we go ahead and upload. If they don't match (or if we uploaded the file and got a different file name back in the metadata) then we display an error message to the user and prompt him to upload or download similar to the manual sync dialog.

There is still a race condition here where the file could be modified on dropbox between the time where we request the metadata and when we actually upload the file. But that should rarely (if ever) happen, and we should get an error response back from dropbox and alert the user. I still need to test that case.

I also added a flag that gets set when an upload fails or is cancelled so that the manual sync dialog is displayed on the next sync.
