### PR TITLE
Filter logic

### DIFF
--- a/Classes/AndFilter.h
+++ b/Classes/AndFilter.h
@@ -41,25 +41,17 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
 #import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@interface AndFilter : NSObject <Filter> {
+	NSMutableArray *filters;
+}
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@property (nonatomic, readonly) NSArray *filters;
+
+- (void) addFilter:(id<Filter>)filter;
+- (BOOL) apply:(id)object;
 
 @end

--- a/Classes/AndFilter.m
+++ b/Classes/AndFilter.m
@@ -41,25 +41,47 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
+
+#import "AndFilter.h"
 #import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@implementation AndFilter
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@synthesize filters;
+
+- (id) init {
+	self = [super init];
+	if (self) {
+		filters = [[NSMutableArray alloc] init];
+	}
+	return self;
+}
+
+- (void) addFilter:(id<Filter>)filter {
+	if (filter) {
+		[filters addObject:filter];
+	}
+}
+
+- (BOOL) apply:(id)object {
+	if (filters.count == 0) {
+		return YES;
+	}
+	
+	Task *input = (Task*)object;
+	
+	for (id<Filter> filter in filters) {
+		if (![filter apply:input]) {
+			return NO;
+		}
+	}
+	
+	return YES;
+}
+
+- (void) dealloc {
+	[super dealloc];
+	[filters release];
+}
 
 @end

--- a/Classes/ByContextFilter.h
+++ b/Classes/ByContextFilter.h
@@ -41,25 +41,18 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
 #import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@interface ByContextFilter : NSObject <Filter> {
+	NSArray *contexts;
+}
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@property (nonatomic, readonly) NSArray *contexts;
+
+- (id) initWithContexts:(NSArray*)contextList;
+
+- (BOOL) apply:(id)object;
 
 @end

--- a/Classes/ByContextFilter.m
+++ b/Classes/ByContextFilter.m
@@ -41,25 +41,43 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
+
+#import "ByContextFilter.h"
 #import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@implementation ByContextFilter
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@synthesize contexts;
+
+- (id) initWithContexts:(NSArray *)contextList {
+	self = [super init];
+	
+	if (self) {
+		contexts = [contextList retain];
+	}
+	
+	return self;	
+}
+
+- (BOOL) apply:(id)object {
+	if (contexts.count == 0) {
+		return YES;
+	}
+	
+	Task *input = (Task*)object;
+	
+	for (NSString* context in input.contexts) {
+		if ([contexts containsObject:context]) {
+			return YES;
+		}
+	}
+	
+	return NO;
+}
+
+- (void) dealloc {
+	[super dealloc];
+	[contexts release];
+}
 
 @end

--- a/Classes/ByPriorityFilter.h
+++ b/Classes/ByPriorityFilter.h
@@ -41,25 +41,18 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
 #import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@interface ByPriorityFilter : NSObject <Filter> {
+	NSArray *priorities;
+}
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@property (nonatomic, readonly) NSArray *priorities;
+
+- (id) initWithPriorities:(NSArray*)priorityList;
+
+- (BOOL) apply:(id)object;
 
 @end

--- a/Classes/ByPriorityFilter.m
+++ b/Classes/ByPriorityFilter.m
@@ -41,25 +41,41 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
+
+#import "ByPriorityFilter.h"
 #import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@implementation ByPriorityFilter
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@synthesize priorities;
+
+- (id) initWithPriorities:(NSArray *)priorityList {
+	self = [super init];
+	
+	if (self) {
+		priorities = [priorityList retain];
+	}
+	
+	return self;	
+}
+
+- (BOOL) apply:(id)object {
+	if (priorities.count == 0) {
+		return YES;
+	}
+	
+	Task *input = (Task*)object;
+	
+	if ([priorities containsObject:input.priority]) {
+		return YES;
+	}
+	
+	return NO;
+}
+
+- (void) dealloc {
+	[super dealloc];
+	[priorities release];
+}
 
 @end

--- a/Classes/ByProjectFilter.h
+++ b/Classes/ByProjectFilter.h
@@ -41,25 +41,18 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
 #import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@interface ByProjectFilter : NSObject <Filter> {
+	NSArray *projects;
+}
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@property (nonatomic, readonly) NSArray *projects;
+
+- (id) initWithProjects:(NSArray*)projectList;
+
+- (BOOL) apply:(id)object;
 
 @end

--- a/Classes/ByProjectFilter.m
+++ b/Classes/ByProjectFilter.m
@@ -41,25 +41,43 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
+
+#import "ByProjectFilter.h"
 #import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@implementation ByProjectFilter
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@synthesize projects;
+
+- (id) initWithProjects:(NSArray *)projectList {
+	self = [super init];
+	
+	if (self) {
+		projects = [projectList retain];
+	}
+	
+	return self;	
+}
+
+- (BOOL) apply:(id)object {
+	if (projects.count == 0) {
+		return YES;
+	}
+	
+	Task *input = (Task*)object;
+	
+	for (NSString* project in input.projects) {
+		if ([projects containsObject:project]) {
+			return YES;
+		}
+	}
+	
+	return NO;
+}
+
+- (void) dealloc {
+	[super dealloc];
+	[projects release];
+}
 
 @end

--- a/Classes/ByTextFilter.h
+++ b/Classes/ByTextFilter.h
@@ -41,25 +41,20 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
 #import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@interface ByTextFilter : NSObject <Filter> {
+	NSString *text;
+	BOOL caseSensitive;
+}
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@property (nonatomic, readonly) NSString *text;
+@property (nonatomic, readonly) BOOL caseSensitive;
+
+- (id) initWithText:(NSString*)aText caseSensitive:(BOOL)isCaseSensitive;
+
+- (BOOL) apply:(id)object;
 
 @end

--- a/Classes/ByTextFilter.m
+++ b/Classes/ByTextFilter.m
@@ -41,25 +41,54 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
+
+#import "ByTextFIlter.h"
 #import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@implementation ByTextFilter
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@synthesize text, caseSensitive;
+
+- (id) initWithText:(NSString *)aText caseSensitive:(BOOL)isCaseSensitive {
+	self = [super init];
+	
+	if (self) {
+		caseSensitive = isCaseSensitive;
+		if (caseSensitive) {
+			text = [aText retain];
+		} else {
+			text = [[aText uppercaseString] retain];
+		}
+		caseSensitive = isCaseSensitive;
+	}
+	
+	return self;	
+}
+
+- (BOOL) apply:(id)object {
+	if (text.length == 0) {
+		return YES;
+	}
+	
+	Task *input = (Task*)object;
+	
+	NSString *taskText;
+	if (caseSensitive) {
+		taskText = input.text;
+	} else {
+		taskText = [input.text uppercaseString];
+	}
+	
+	if ([taskText rangeOfString:text].location != NSNotFound) {
+		return YES;
+	}
+	
+	return NO;
+}
+
+- (void) dealloc {
+	[super dealloc];
+	[text release];
+}
 
 @end

--- a/Classes/Filter.h
+++ b/Classes/Filter.h
@@ -41,25 +41,11 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@protocol Filter <NSObject>
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+- (BOOL) apply:(id)object;
 
 @end

--- a/Classes/FilterFactory.h
+++ b/Classes/FilterFactory.h
@@ -41,25 +41,16 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
 #import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@interface FilterFactory : NSObject
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
++ (id <Filter>) getAndFilterWithPriorities:(NSArray*)priorities 
+								  contexts:(NSArray*)contexts 
+								  projects:(NSArray*)projects 
+									  text:(NSString*)text 
+							 caseSensitive:(BOOL)caseSensitive;
 
 @end

--- a/Classes/FilterFactory.m
+++ b/Classes/FilterFactory.m
@@ -41,25 +41,40 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+#import "FilterFactory.h"
+#import "AndFilter.h"
+#import "ByPriorityFilter.h"
+#import "ByContextFilter.h"
+#import "ByProjectFilter.h"
+#import "ByTextFilter.h"
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@implementation FilterFactory
+
++ (id <Filter>) getAndFilterWithPriorities:(NSArray*)priorities 
+								  contexts:(NSArray*)contexts 
+								  projects:(NSArray*)projects 
+									  text:(NSString*)text 
+							 caseSensitive:(BOOL)caseSensitive {
+
+	AndFilter *filter = [[[AndFilter alloc] init] autorelease];
+	
+	if (priorities.count > 0) {
+		[filter addFilter:[[[ByPriorityFilter alloc] initWithPriorities:priorities] autorelease]];
+	}
+	
+	if (contexts.count > 0) {
+		[filter addFilter:[[[ByContextFilter alloc] initWithContexts:contexts] autorelease]];
+	}
+	
+	if (projects.count > 0) {
+		[filter addFilter:[[[ByProjectFilter alloc] initWithProjects:projects] autorelease]];
+	}
+	
+	if (text.length > 0) {
+		[filter addFilter:[[[ByTextFilter alloc] initWithText:text caseSensitive:caseSensitive] autorelease]];
+	}
+	return filter;
+}
 
 @end

--- a/Classes/OrFilter.h
+++ b/Classes/OrFilter.h
@@ -41,25 +41,17 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
 #import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@interface OrFilter : NSObject <Filter> {
+	NSMutableArray *filters;
+}
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@property (nonatomic, readonly) NSArray *filters;
+
+- (void) addFilter:(id<Filter>)filter;
+- (BOOL) apply:(id)object;
 
 @end

--- a/Classes/OrFilter.m
+++ b/Classes/OrFilter.m
@@ -41,25 +41,47 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
+
+#import "OrFilter.h"
 #import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@implementation OrFilter
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@synthesize filters;
+
+- (id) init {
+	self = [super init];
+	if (self) {
+		filters = [[NSMutableArray alloc] init];
+	}
+	return self;
+}
+
+- (void) addFilter:(id<Filter>)filter {
+	if (filter) {
+		[filters addObject:filter];
+	}
+}
+
+- (BOOL) apply:(id)object {
+	if (filters.count == 0) {
+		return YES;
+	}
+	
+	Task *input = (Task*)object;
+	
+	for (id<Filter> filter in filters) {
+		if ([filter apply:input]) {
+			return YES;
+		}
+	}
+	
+	return NO;
+}
+
+- (void) dealloc {
+	[super dealloc];
+	[filters release];
+}
 
 @end

--- a/Classes/Strings.h
+++ b/Classes/Strings.h
@@ -1,0 +1,16 @@
+//
+//  Strings.h
+//  todo.txt-touch-ios
+//
+//  Created by Charles Jones on 12/29/11.
+//  Copyright (c) 2011 __MyCompanyName__. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface Strings : NSObject
+
++ (NSString*) insertPaddedString:(NSString *)s atRange:(NSRange)insertAt withString:(NSString *)stringToInsert;
++ (NSRange) calculateSelectedRange:(NSRange)oldRange oldText:(NSString*)oldText newText:(NSString*)newText;
+
+@end

--- a/Classes/Strings.m
+++ b/Classes/Strings.m
@@ -1,0 +1,64 @@
+//
+//  Strings.m
+//  todo.txt-touch-ios
+//
+//  Created by Charles Jones on 12/29/11.
+//  Copyright (c) 2011 __MyCompanyName__. All rights reserved.
+//
+
+#import "Strings.h"
+
+#define SINGLE_SPACE ' '
+
+@implementation Strings
+
++ (NSString*) insertPaddedString:(NSString *)s atRange:(NSRange)insertAt withString:(NSString *)stringToInsert {
+	if (stringToInsert.length == 0) {
+		return s;
+	}	
+	
+	NSMutableString *newText = [NSMutableString stringWithCapacity:(s.length + stringToInsert.length + 2)];
+	
+	if (insertAt.location > 0) {
+		[newText appendString:[s substringToIndex:(insertAt.location)]];
+		if (newText.length > 0 && [newText characterAtIndex:(newText.length - 1)] != SINGLE_SPACE) {
+			[newText appendFormat:@"%c", SINGLE_SPACE];
+		}
+		[newText appendString:stringToInsert];
+		NSUInteger pos = NSMaxRange(insertAt);
+		NSString *postItem = [s substringFromIndex:pos];
+		if (postItem.length == 0 || [postItem characterAtIndex:0] != SINGLE_SPACE) {
+			[newText appendFormat:@"%c", SINGLE_SPACE];
+		}
+		[newText appendString:postItem];
+	} else {
+		[newText appendString:stringToInsert];
+		if (s.length > 0 && [s characterAtIndex:0] != SINGLE_SPACE) {
+			[newText appendFormat:@"%c", SINGLE_SPACE];
+		}	
+		[newText appendString:s];
+	}
+	
+	return newText;
+}
+
++ (NSRange) calculateSelectedRange:(NSRange)oldRange oldText:(NSString*)oldText newText:(NSString*)newText {
+	NSUInteger length = oldRange.length;
+	
+	if (newText == nil) {
+		return NSMakeRange(0, length);
+	}
+	
+	if (oldText == nil) {
+		return NSMakeRange(newText.length, 0);
+	}
+	
+	NSInteger pos = oldRange.location + (newText.length - oldText.length);
+	pos = pos < 0 ? 0 : pos;
+	pos = pos > newText.length ? newText.length : pos;
+	
+	return NSMakeRange(pos, length);
+}
+
+
+@end

--- a/Classes/Task.m
+++ b/Classes/Task.m
@@ -117,7 +117,7 @@
 - (void)markIncomplete {
 	if (completed) {
 		[completionDate release];
-		completionDate = nil;
+		completionDate = [[NSString string] retain];
 		completed = NO;
 	}
 }
@@ -207,7 +207,7 @@
 		return NO;
 	}
 	
-	if (![projects isEqualToArray:[task contexts]]) {
+	if (![projects isEqualToArray:[task projects]]) {
 		return NO;
 	}
 	

--- a/Classes/TaskBagImpl.h
+++ b/Classes/TaskBagImpl.h
@@ -43,6 +43,7 @@
  */
 #import "TaskBag.h"
 #import "LocalTaskRepository.h"
+#import "Filter.h"
 
 @interface TaskBagImpl : NSObject <TaskBag> {
     id <LocalTaskRepository> localTaskRepository;
@@ -58,7 +59,7 @@
 - (Task*) taskAtIndex:(NSUInteger)index;
 - (NSUInteger) indexOfTask:(Task*)task;
 - (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(NSObject*)filterSpec withSortOrder:(Sort*)sortOrder;
+- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
 - (int) size;
 - (NSArray*) projects;
 - (NSArray*) contexts;

--- a/Classes/TaskBagImpl.m
+++ b/Classes/TaskBagImpl.m
@@ -47,6 +47,7 @@
 #import "RemoteClient.h"
 #import "LocalFileTaskRepository.h"
 #import "TaskIo.h"
+#import "Filter.h"
 
 Task* find(NSArray *tasks, Task *task) {
 	for(int i = 0; i < [tasks count]; i++) {
@@ -146,27 +147,25 @@ Task* find(NSArray *tasks, Task *task) {
     return [self tasksWithFilter:nil withSortOrder:nil];
 }
 
-- (NSArray*) tasksWithFilter:(NSObject*)filterSpec withSortOrder:(Sort*)sortOrder {
+- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder {
 	NSMutableArray *localTasks = [NSMutableArray arrayWithCapacity:[tasks count]];
-	// TODO: implement filtering
-	// FIXME: right now we just assume that filterSpec is a string
-	// and we will return only those tasks that contain that string.
-	// Proper filtering still to come
-	if (filterSpec != nil) {
-		NSString *searchTerm = (NSString*)filterSpec; 
+	if (filter != nil) {
 		for (Task* task in tasks) {
-			if ([task.text rangeOfString:searchTerm options:NSCaseInsensitiveSearch].location != NSNotFound) {
+			if ([filter apply:task]) {
 				[localTasks addObject:task];
 			}
 		}
 	} else {	
 		[localTasks setArray:tasks];
 	}
-	
-	if (sortOrder) {
-		[localTasks sortUsingSelector:[sortOrder comparator]];
+		
+	if (!sortOrder) {
+		sortOrder = [Sort byName:SortPriority];
 	}
-    return localTasks;
+	
+	[localTasks sortUsingSelector:[sortOrder comparator]];
+	
+	return localTasks;
 }
 
 - (int) size {

--- a/Classes/TaskEditViewController.m
+++ b/Classes/TaskEditViewController.m
@@ -50,59 +50,8 @@
 #import "ActionSheetPicker.h"
 #import "PriorityTextSplitter.h"
 #import "TaskUtil.h"
+#import "Strings.h"
 #import <QuartzCore/QuartzCore.h>
-
-#define SINGLE_SPACE ' '
-
-NSRange calculateSelectedRange(NSRange oldRange, NSString *oldText, NSString* newText) {
-	NSUInteger length = oldRange.length;
-	
-	if (newText == nil) {
-		return NSMakeRange(0, length);
-	}
-	
-	if (oldText == nil) {
-		return NSMakeRange(newText.length, 0);
-	}
-	
-	NSInteger pos = oldRange.location + (newText.length - oldText.length);
-	pos = pos < 0 ? 0 : pos;
-	pos = pos > newText.length ? newText.length : pos;
-
-	return NSMakeRange(pos, length);
-}
-
-NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) {
-	NSMutableString *newText = [NSMutableString stringWithCapacity:(s.length + stringToInsert.length + 2)];
-	
-	if (insertAt.location > 0) {
-		[newText appendString:[s substringToIndex:(insertAt.location)]];
-		if (newText.length > 0 && [newText characterAtIndex:(newText.length - 1)] != SINGLE_SPACE) {
-			[newText appendFormat:@"%c", SINGLE_SPACE];
-		}
-		[newText appendString:stringToInsert];
-		NSUInteger pos = NSMaxRange(insertAt);
-		NSString *postItem = [s substringFromIndex:pos];
-		if (postItem.length > 0) {
-			if ([postItem characterAtIndex:0] != SINGLE_SPACE) {
-				[newText appendFormat:@"%c", SINGLE_SPACE];
-			}
-			[newText appendString:postItem];
-		}
-	} else {
-		[newText appendString:stringToInsert];
-		if (s.length > 0 && [s characterAtIndex:0] != SINGLE_SPACE) {
-			[newText appendFormat:@"%c", SINGLE_SPACE];
-		}	
-		[newText appendString:s];
-	}
-	
-	if (newText.length > 0 && [newText characterAtIndex:(newText.length - 1)] != SINGLE_SPACE) {
-		[newText appendFormat:@"%c", SINGLE_SPACE];
-	}
-	
-	return newText;
-}
 
 @implementation TaskEditViewController
 
@@ -298,7 +247,7 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 								 [selectedPriority fileFormat],
 								 [[PriorityTextSplitter split:textView.text] text]];
 		}
-		curSelectedRange = calculateSelectedRange(curSelectedRange, textView.text, newText);
+		curSelectedRange = [Strings calculateSelectedRange:curSelectedRange oldText:textView.text newText:newText];
 		textView.text = newText;
 		textView.selectedRange = curSelectedRange;
 	}
@@ -313,8 +262,8 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 		
 		if (! [TaskUtil taskHasProject:textView.text project:item]) {
 			item = [NSString stringWithFormat:@"+%@", item];
-			NSString *newText = insertPadded(textView.text, curSelectedRange, item);
-			curSelectedRange = calculateSelectedRange(curSelectedRange, textView.text, newText);
+			NSString *newText = [Strings insertPaddedString:textView.text atRange:curSelectedRange withString:item];
+			curSelectedRange = [Strings calculateSelectedRange:curSelectedRange oldText:textView.text newText:newText];
 			textView.text = newText;
 			textView.selectedRange = curSelectedRange;
 		}
@@ -330,8 +279,8 @@ NSString* insertPadded(NSString *s, NSRange insertAt, NSString *stringToInsert) 
 		
 		if (! [TaskUtil taskHasContext:textView.text context:item]) {
 			item = [NSString stringWithFormat:@"@%@", item];
-			NSString *newText = insertPadded(textView.text, curSelectedRange, item);
-			curSelectedRange = calculateSelectedRange(curSelectedRange, textView.text, newText);
+			NSString *newText = [Strings insertPaddedString:textView.text atRange:curSelectedRange withString:item];
+			curSelectedRange = [Strings calculateSelectedRange:curSelectedRange oldText:textView.text newText:newText];
 			textView.text = newText;
 			textView.selectedRange = curSelectedRange;
 		}

--- a/Classes/todo_txt_touch_iosViewController.m
+++ b/Classes/todo_txt_touch_iosViewController.m
@@ -51,6 +51,7 @@
 #import "TaskViewController.h"
 #import "todo_txt_touch_iosViewController.h"
 #import "todo_txt_touch_iosAppDelegate.h"
+#import "FilterFactory.h"
 
 static BOOL savedOfflineMode = NO;
 static BOOL needSync = NO;
@@ -87,8 +88,9 @@ static BOOL needSync = NO;
 	
 	// reload searchbar tableview data if necessary
 	if (self.savedSearchTerm)
-	{
-		self.searchResults = [[todo_txt_touch_iosAppDelegate sharedTaskBag] tasksWithFilter:savedSearchTerm withSortOrder:sort];
+	{	
+		id<Filter> filter = [FilterFactory getAndFilterWithPriorities:nil contexts:nil projects:nil text:savedSearchTerm caseSensitive:NO];
+		self.searchResults = [[todo_txt_touch_iosAppDelegate sharedTaskBag] tasksWithFilter:filter withSortOrder:sort];
 		[self.searchDisplayController.searchResultsTableView reloadData];
 	}
 }
@@ -262,7 +264,8 @@ static BOOL needSync = NO;
 
 - (void)handleSearchForTerm:(NSString *)searchTerm {
 	self.savedSearchTerm = searchTerm;
-	self.searchResults = [[todo_txt_touch_iosAppDelegate sharedTaskBag] tasksWithFilter:savedSearchTerm withSortOrder:sort];
+	id<Filter> filter = [FilterFactory getAndFilterWithPriorities:nil contexts:nil projects:nil text:savedSearchTerm caseSensitive:NO];
+	self.searchResults = [[todo_txt_touch_iosAppDelegate sharedTaskBag] tasksWithFilter:filter withSortOrder:sort];
 }
 
 - (BOOL)searchDisplayController:(UISearchDisplayController *)controller 

--- a/Todo-txt-unit-tests/AndFilterTest.h
+++ b/Todo-txt-unit-tests/AndFilterTest.h
@@ -41,25 +41,9 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+#import <SenTestingKit/SenTestingKit.h>
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@interface AndFilterTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/AndFilterTest.m
+++ b/Todo-txt-unit-tests/AndFilterTest.m
@@ -41,25 +41,45 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
+
+#import "AndFilterTest.h"
+#import "AndFilter.h"
+#import "ByPriorityFilter.h"
+#import "ByProjectFilter.h"
+#import "ByContextFIlter.h"
+#import "ByTextFilter.h"
 #import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@implementation AndFilterTest
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+- (void)testNoFilters
+{
+	AndFilter *andFilter = [[[AndFilter alloc] init] autorelease];
+	STAssertTrue([andFilter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) abc 123"] autorelease]], @"apply was not true");
+}
+
+- (void)testMultipleFilters_matchesBoth
+{
+	AndFilter *andFilter = [[[AndFilter alloc] init] autorelease];
+	[andFilter addFilter:[[ByPriorityFilter alloc] initWithPriorities:[[NSArray arrayWithObject:[Priority byName:PriorityA]] autorelease]]];
+	[andFilter addFilter:[[[ByTextFilter alloc] initWithText:@"abc" caseSensitive:false] autorelease]];
+	STAssertTrue([andFilter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) abc 123"] autorelease]], @"apply was not true");
+}
+
+- (void)testMultipleFilters_matchesOnlyOne
+{
+	AndFilter *andFilter = [[[AndFilter alloc] init] autorelease];
+	[andFilter addFilter:[[ByPriorityFilter alloc] initWithPriorities:[[NSArray arrayWithObject:[Priority byName:PriorityA]] autorelease]]];
+	[andFilter addFilter:[[[ByTextFilter alloc] initWithText:@"abc" caseSensitive:false] autorelease]];
+	STAssertFalse([andFilter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) hello world"] autorelease]], @"apply was not false");
+}
+
+- (void)testMultipleFilters_matchesNone
+{
+	AndFilter *andFilter = [[[AndFilter alloc] init] autorelease];
+	[andFilter addFilter:[[ByPriorityFilter alloc] initWithPriorities:[[NSArray arrayWithObject:[Priority byName:PriorityA]] autorelease]]];
+	[andFilter addFilter:[[[ByTextFilter alloc] initWithText:@"abc" caseSensitive:false] autorelease]];
+	STAssertFalse([andFilter apply:[[[Task alloc] initWithId:1 withRawText:@"(B) hello world"] autorelease]], @"apply was not false");
+}
 
 @end

--- a/Todo-txt-unit-tests/ByContextFilterTest.h
+++ b/Todo-txt-unit-tests/ByContextFilterTest.h
@@ -41,25 +41,9 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+#import <SenTestingKit/SenTestingKit.h>
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@interface ByContextFilterTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/ByContextFilterTest.m
+++ b/Todo-txt-unit-tests/ByContextFilterTest.m
@@ -1,0 +1,122 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "ByContextFilterTest.h"
+#import "ByContextFilter.h"
+#import "Task.h"
+
+@implementation ByContextFilterTest
+
+- (void)testConstructor_nilContexts
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:nil];
+	STAssertNil(filter.contexts, @"contexts shoud be nil");
+	STAssertEquals(0U, filter.contexts.count, @"contexts count should be zero");
+}
+
+- (void)testConstructor_valid
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertNotNil(filter.contexts, @"contexts shoud not be nil");
+	STAssertEquals(3U, filter.contexts.count, @"contexts count should be three");
+	STAssertEqualObjects(@"abc", [filter.contexts objectAtIndex:0], @"first context should be \"abc\"");
+	STAssertEqualObjects(@"123", [filter.contexts objectAtIndex:1], @"second context should be \"123\"");
+	STAssertEqualObjects(@"hello", [filter.contexts objectAtIndex:2], @"third context should be \"hello\"");
+}
+
+- (void)testFilter_noFilterContexts_noTaskContexts
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:nil];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterContext_noTaskContexts
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:[NSArray arrayWithObject:@"abc"]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world"] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_noFilterContext_oneTaskContexts
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:nil];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world @abc"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterContext_sameTaskContext
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:[NSArray arrayWithObject:@"abc"]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world @abc"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterContext_differentTaskContext
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:[NSArray arrayWithObject:@"abc"]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world @123"] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_multipleFilterContext_oneSameTaskContext
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world @123"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_multipleFilterContext_multipleTaskContext
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world @123 @goodbye"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_multipleFilterContext_multipleSameTaskContext
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world @123 @hello"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_multipleFilterContext_multipleDifferentTaskContext
+{
+    ByContextFilter *filter = [[ByContextFilter alloc] initWithContexts:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world @xyz @goodbye"] autorelease]], @"apply was not false");
+}
+
+@end

--- a/Todo-txt-unit-tests/ByPriorityFilterTest.h
+++ b/Todo-txt-unit-tests/ByPriorityFilterTest.h
@@ -41,25 +41,9 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+#import <SenTestingKit/SenTestingKit.h>
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@interface ByPriorityFilterTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/ByPriorityFilterTest.m
+++ b/Todo-txt-unit-tests/ByPriorityFilterTest.m
@@ -1,0 +1,109 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "ByPriorityFilterTest.h"
+#import "ByPriorityFilter.h"
+#import "Task.h"
+
+@implementation ByPriorityFilterTest
+
+- (void)testConstructor_nilPriorities
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:nil];
+	STAssertNil(filter.priorities, @"priorities shoud be nil");
+	STAssertEquals(0U, filter.priorities.count, @"priorities count should be zero");
+}
+
+- (void)testConstructor_valid
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:[NSArray arrayWithObjects:[Priority byName:PriorityA], [Priority byName:PriorityB], nil]];
+	STAssertNotNil(filter.priorities, @"priorities shoud not be nil");
+	STAssertEquals(2U, filter.priorities.count, @"priorities count should be three");
+	STAssertEquals([Priority byName:PriorityA], [filter.priorities objectAtIndex:0], @"first priority should be \"A\"");
+	STAssertEquals([Priority byName:PriorityB], [filter.priorities objectAtIndex:1], @"second priority should be \"B\"");
+}
+
+- (void)testFilter_noFilterPriorities_noTaskPriorities
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:nil];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterPriority_noTaskPriorities
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:[NSArray arrayWithObject:[Priority byName:PriorityA]]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world"] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_noFilterPriority_oneTaskPriorities
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:nil];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) hello world"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterPriority_sameTaskPriority
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:[NSArray arrayWithObject:[Priority byName:PriorityA]]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) hello world"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterPriority_differentTaskPriority
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:[NSArray arrayWithObject:[Priority byName:PriorityA]]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"(B) hello world"] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_multipleFilterPriority_oneSameTaskPriority
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:[NSArray arrayWithObjects:[Priority byName:PriorityA], [Priority byName:PriorityB], nil]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) hello world"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_multipleFilterPriority_oneDifferentTaskPriority
+{
+    ByPriorityFilter *filter = [[ByPriorityFilter alloc] initWithPriorities:[NSArray arrayWithObjects:[Priority byName:PriorityA], [Priority byName:PriorityB], nil]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"(C) hello world"] autorelease]], @"apply was not false");
+}
+
+@end

--- a/Todo-txt-unit-tests/ByProjectFilterTest.h
+++ b/Todo-txt-unit-tests/ByProjectFilterTest.h
@@ -41,25 +41,9 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+#import <SenTestingKit/SenTestingKit.h>
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@interface ByProjectFilterTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/ByProjectFilterTest.m
+++ b/Todo-txt-unit-tests/ByProjectFilterTest.m
@@ -1,0 +1,122 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "ByProjectFilterTest.h"
+#import "ByProjectFilter.h"
+#import "Task.h"
+
+@implementation ByProjectFilterTest
+
+- (void)testConstructor_nilProjects
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:nil];
+	STAssertNil(filter.projects, @"projects shoud be nil");
+	STAssertEquals(0U, filter.projects.count, @"projects count should be zero");
+}
+
+- (void)testConstructor_valid
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertNotNil(filter.projects, @"projects shoud not be nil");
+	STAssertEquals(3U, filter.projects.count, @"projects count should be three");
+	STAssertEqualObjects(@"abc", [filter.projects objectAtIndex:0], @"first project should be \"abc\"");
+	STAssertEqualObjects(@"123", [filter.projects objectAtIndex:1], @"second project should be \"123\"");
+	STAssertEqualObjects(@"hello", [filter.projects objectAtIndex:2], @"third project should be \"hello\"");
+}
+
+- (void)testFilter_noFilterProjects_noTaskProjects
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:nil];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterProject_noTaskProjects
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:[NSArray arrayWithObject:@"abc"]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world"] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_noFilterProject_oneTaskProjects
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:nil];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world +abc"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterProject_sameTaskProject
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:[NSArray arrayWithObject:@"abc"]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world +abc"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_oneFilterProject_differentTaskProject
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:[NSArray arrayWithObject:@"abc"]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world +123"] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_multipleFilterProject_oneSameTaskProject
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world +123"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_multipleFilterProject_multipleTaskProject
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world +123 +goodbye"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_multipleFilterProject_multipleSameTaskProject
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world +123 +hello"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_multipleFilterProject_multipleDifferentTaskProject
+{
+    ByProjectFilter *filter = [[ByProjectFilter alloc] initWithProjects:[NSArray arrayWithObjects:@"abc", @"123", @"hello", nil]];
+	STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world +xyz +goodbye"] autorelease]], @"apply was not false");
+}
+
+@end

--- a/Todo-txt-unit-tests/ByTextFilterTest.h
+++ b/Todo-txt-unit-tests/ByTextFilterTest.h
@@ -41,25 +41,9 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+#import <SenTestingKit/SenTestingKit.h>
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@interface ByTextFilterTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/ByTextFilterTest.m
+++ b/Todo-txt-unit-tests/ByTextFilterTest.m
@@ -1,0 +1,123 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "ByTextFilterTest.h"
+#import "ByTextFilter.h"
+#import "Task.h"
+
+@implementation ByTextFilterTest
+
+- (void)testConstructor_nullText_false
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:nil caseSensitive:NO];
+	STAssertNil(filter.text, @"text should be nil");
+    STAssertFalse(filter.caseSensitive, @"caseSensitive should be false");
+}
+
+- (void)testConstructor_nullText_true
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:nil caseSensitive:YES];
+	STAssertNil(filter.text, @"text should be nil");
+    STAssertTrue(filter.caseSensitive, @"caseSensitive should be true");
+}
+
+- (void)testConstructor_valid_false
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"abc" caseSensitive:NO];
+	STAssertNotNil(filter.text, @"text should not be nil");
+	STAssertEqualObjects(@"ABC", filter.text, @"should be equal");
+    STAssertFalse(filter.caseSensitive, @"caseSensitive should be false");
+}
+
+- (void)testConstructor_valid_true
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"abc" caseSensitive:YES];
+	STAssertNotNil(filter.text, @"text should not be nil");
+	STAssertEqualObjects(@"abc", filter.text, @"should be equal");
+    STAssertTrue(filter.caseSensitive, @"caseSensitive should be true");
+}
+
+- (void)testFilter_noText_noTaskText
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"" caseSensitive:NO];
+    STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@""] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_noText_hasTaskText
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"" caseSensitive:NO];
+    STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"abc"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_abcText_noTaskText
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"abc" caseSensitive:NO];
+    STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@""] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_abcText_notContainedTaskText
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"abc" caseSensitive:NO];
+    STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello world"] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_abcText_containsTaskText_wrongCase_caseSensitive
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"abc" caseSensitive:YES];
+    STAssertFalse([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello ABC world"] autorelease]], @"apply was not false");
+}
+
+- (void)testFilter_abcText_containsTaskText_wrongCase_caseInSensitive
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"abc" caseSensitive:NO];
+    STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"hello ABC world"] autorelease]], @"apply was not true");
+}
+
+- (void)testFilter_abcText_containsTaskTextNotPadded_wrongCase_caseInSensitive
+{
+	ByTextFilter *filter = [[ByTextFilter alloc] initWithText:@"abc" caseSensitive:NO];
+    STAssertTrue([filter apply:[[[Task alloc] initWithId:1 withRawText:@"helloABCworld"] autorelease]], @"apply was not true");
+}
+
+@end

--- a/Todo-txt-unit-tests/ContextParserTest.h
+++ b/Todo-txt-unit-tests/ContextParserTest.h
@@ -44,6 +44,6 @@
 
 #import <SenTestingKit/SenTestingKit.h>
 
-@interface Todo_txt_unit_tests : SenTestCase
+@interface ContextParserTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/ContextParserTest.m
+++ b/Todo-txt-unit-tests/ContextParserTest.m
@@ -1,0 +1,99 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "ContextParserTest.h"
+#import "ContextParser.h"
+
+@implementation ContextParserTest
+
+- (void)test_empty
+{
+    NSString *input = @"";
+	NSArray *strings = [ContextParser parse:input];
+	STAssertEqualObjects([NSArray array], strings, @"Should be empty");
+}
+
+- (void)test_nil
+{
+    NSString *input = nil;
+	NSArray *strings = [ContextParser parse:input];
+	STAssertEqualObjects([NSArray array], strings, @"Should be empty");
+}
+
+- (void)test_withoutContext
+{
+    NSString *input = @"a simple string";
+	NSArray *strings = [ContextParser parse:input];
+	STAssertEqualObjects([NSArray array], strings, @"Should be empty");
+}
+
+- (void)test_withContext
+{
+    NSString *input = @"a simple @string";
+	NSArray *strings = [ContextParser parse:input];
+	STAssertEquals(1U, strings.count, @"Should be one match");
+	STAssertTrue([strings containsObject:@"string"], @"should contain \"string\"");
+}
+
+- (void)test_withMultipleContexts
+{
+    NSString *input = @"a simple @string @test";
+	NSArray *strings = [ContextParser parse:input];
+	STAssertEquals(2U, strings.count, @"Should be two matches");
+	STAssertTrue([strings containsObject:@"string"], @"should contain \"string\"");
+	STAssertTrue([strings containsObject:@"test"], @"should contain \"test\"");
+}
+
+- (void)test_withInterspersedContexts
+{
+    NSString *input = @"@more complex @case with a @string @test";
+	NSArray *strings = [ContextParser parse:input];
+	STAssertEquals(4U, strings.count, @"Should be four matches");
+	STAssertTrue([strings containsObject:@"more"], @"should contain \"more\"");
+	STAssertTrue([strings containsObject:@"case"], @"should contain \"case\"");
+	STAssertTrue([strings containsObject:@"string"], @"should contain \"string\"");
+	STAssertTrue([strings containsObject:@"test"], @"should contain \"test\"");
+}
+
+@end

--- a/Todo-txt-unit-tests/OrFilterTest.h
+++ b/Todo-txt-unit-tests/OrFilterTest.h
@@ -41,25 +41,9 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
-#import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+#import <SenTestingKit/SenTestingKit.h>
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+@interface OrFilterTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/OrFilterTest.m
+++ b/Todo-txt-unit-tests/OrFilterTest.m
@@ -41,25 +41,45 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <Foundation/Foundation.h>
+
+#import "OrFilterTest.h"
+#import "OrFilter.h"
+#import "ByPriorityFilter.h"
+#import "ByProjectFilter.h"
+#import "ByContextFIlter.h"
+#import "ByTextFilter.h"
 #import "Task.h"
-#import "Sort.h"
-#import "Filter.h"
 
-@protocol TaskBag <NSObject>
+@implementation OrFilterTest
 
-- (void) reload;
-- (void) reloadWithFile:(NSString*)file;
-- (void) addAsTask:(NSString*)input;
-- (Task*) update:(Task*)task;
-- (void) remove:(Task*)task;
-- (Task*) taskAtIndex:(NSUInteger)index;
-- (NSUInteger) indexOfTask:(Task*)task;
-- (NSArray*) tasks;
-- (NSArray*) tasksWithFilter:(id<Filter>)filter withSortOrder:(Sort*)sortOrder;
-- (int) size;
-- (NSArray*) projects;
-- (NSArray*) contexts;
-- (NSArray*) priorities;
+- (void)testNoFilters
+{
+	OrFilter *orFilter = [[[OrFilter alloc] init] autorelease];
+	STAssertTrue([orFilter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) abc 123"] autorelease]], @"apply was not true");
+}
+
+- (void)testMultipleFilters_matchesBoth
+{
+	OrFilter *orFilter = [[[OrFilter alloc] init] autorelease];
+	[orFilter addFilter:[[ByPriorityFilter alloc] initWithPriorities:[[NSArray arrayWithObject:[Priority byName:PriorityA]] autorelease]]];
+	[orFilter addFilter:[[[ByTextFilter alloc] initWithText:@"abc" caseSensitive:false] autorelease]];
+	STAssertTrue([orFilter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) abc 123"] autorelease]], @"apply was not true");
+}
+
+- (void)testMultipleFilters_matchesOnlyOne
+{
+	OrFilter *orFilter = [[[OrFilter alloc] init] autorelease];
+	[orFilter addFilter:[[ByPriorityFilter alloc] initWithPriorities:[[NSArray arrayWithObject:[Priority byName:PriorityA]] autorelease]]];
+	[orFilter addFilter:[[[ByTextFilter alloc] initWithText:@"abc" caseSensitive:false] autorelease]];
+	STAssertTrue([orFilter apply:[[[Task alloc] initWithId:1 withRawText:@"(A) hello world"] autorelease]], @"apply was not true");
+}
+
+- (void)testMultipleFilters_matchesNone
+{
+	OrFilter *orFilter = [[[OrFilter alloc] init] autorelease];
+	[orFilter addFilter:[[ByPriorityFilter alloc] initWithPriorities:[[NSArray arrayWithObject:[Priority byName:PriorityA]] autorelease]]];
+	[orFilter addFilter:[[[ByTextFilter alloc] initWithText:@"abc" caseSensitive:false] autorelease]];
+	STAssertFalse([orFilter apply:[[[Task alloc] initWithId:1 withRawText:@"(B) hello world"] autorelease]], @"apply was not false");
+}
 
 @end

--- a/Todo-txt-unit-tests/PriorityTest.h
+++ b/Todo-txt-unit-tests/PriorityTest.h
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface PriorityTest : SenTestCase
+
+@end

--- a/Todo-txt-unit-tests/PriorityTest.m
+++ b/Todo-txt-unit-tests/PriorityTest.m
@@ -1,0 +1,135 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "PriorityTest.h"
+#import "Priority.h"
+
+@implementation PriorityTest
+
+- (void)testAccessors_simple
+{
+	STAssertEquals(@"A", [Priority byName:PriorityA].code, @"should be A");
+	STAssertEquals(@"A", [Priority byName:PriorityA].listFormat, @"should be A");
+	STAssertEquals(@"A", [Priority byName:PriorityA].detailFormat, @"should be A");
+	STAssertEquals(@"(A)", [Priority byName:PriorityA].fileFormat, @"should be (A)");
+}
+
+- (void)testToPriority_A {
+	STAssertEquals([Priority byName:PriorityA], [Priority byCode:@"A"], @"Should be the same object");
+}
+
+- (void)testToPriority_Z {
+	STAssertEquals([Priority byName:PriorityZ], [Priority byCode:@"Z"], @"Should be the same object");
+}
+
+- (void)testToPriority_invalid {
+	STAssertEquals([Priority NONE], [Priority byCode:@"9"], @"Invalid Priority should return NONE");
+}
+
+- (void)testRange_all {
+	NSArray *all = [Priority all];
+	STAssertEquals(27U, all.count, @"Should be 27 priorities, including NONE");
+	STAssertEquals([Priority NONE], [all objectAtIndex:0], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityA], [all objectAtIndex:1], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityB], [all objectAtIndex:2], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityC], [all objectAtIndex:3], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityD], [all objectAtIndex:4], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityE], [all objectAtIndex:5], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityF], [all objectAtIndex:6], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityG], [all objectAtIndex:7], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityH], [all objectAtIndex:8], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityI], [all objectAtIndex:9], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityJ], [all objectAtIndex:10], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityK], [all objectAtIndex:11], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityL], [all objectAtIndex:12], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityM], [all objectAtIndex:13], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityN], [all objectAtIndex:14], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityO], [all objectAtIndex:15], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityP], [all objectAtIndex:16], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityQ], [all objectAtIndex:17], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityR], [all objectAtIndex:18], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityS], [all objectAtIndex:19], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityT], [all objectAtIndex:20], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityU], [all objectAtIndex:21], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityV], [all objectAtIndex:22], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityW], [all objectAtIndex:23], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityX], [all objectAtIndex:24], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityY], [all objectAtIndex:25], @"Invalid Priority in *all* list");
+	STAssertEquals([Priority byName:PriorityZ], [all objectAtIndex:26], @"Invalid Priority in *all* list");
+}
+
+- (void)testRange_allCodes {
+	NSArray *allCodes = [Priority allCodes];
+	STAssertEquals(27U, allCodes.count, @"Should be 27 priorities, including NONE");
+	STAssertEqualObjects([[Priority NONE] code], [allCodes objectAtIndex:0], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityA] code], [allCodes objectAtIndex:1], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityB] code], [allCodes objectAtIndex:2], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityC] code], [allCodes objectAtIndex:3], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityD] code], [allCodes objectAtIndex:4], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityE] code], [allCodes objectAtIndex:5], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityF] code], [allCodes objectAtIndex:6], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityG] code], [allCodes objectAtIndex:7], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityH] code], [allCodes objectAtIndex:8], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityI] code], [allCodes objectAtIndex:9], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityJ] code], [allCodes objectAtIndex:10], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityK] code], [allCodes objectAtIndex:11], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityL] code], [allCodes objectAtIndex:12], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityM] code], [allCodes objectAtIndex:13], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityN] code], [allCodes objectAtIndex:14], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityO] code], [allCodes objectAtIndex:15], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityP] code], [allCodes objectAtIndex:16], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityQ] code], [allCodes objectAtIndex:17], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityR] code], [allCodes objectAtIndex:18], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityS] code], [allCodes objectAtIndex:19], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityT] code], [allCodes objectAtIndex:20], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityU] code], [allCodes objectAtIndex:21], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityV] code], [allCodes objectAtIndex:22], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityW] code], [allCodes objectAtIndex:23], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityX] code], [allCodes objectAtIndex:24], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityY] code], [allCodes objectAtIndex:25], @"Invalid Priority in *allCodes* list");
+	STAssertEquals([[Priority byName:PriorityZ] code], [allCodes objectAtIndex:26], @"Invalid Priority in *allCodes* list");
+}
+
+
+@end

--- a/Todo-txt-unit-tests/PriorityTextSplitterTest.h
+++ b/Todo-txt-unit-tests/PriorityTextSplitterTest.h
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface PriorityTextSplitterTest : SenTestCase
+
+@end

--- a/Todo-txt-unit-tests/PriorityTextSplitterTest.m
+++ b/Todo-txt-unit-tests/PriorityTextSplitterTest.m
@@ -1,0 +1,121 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "PriorityTextSplitterTest.h"
+#import "Priority.h"
+#import "PriorityTextSplitter.h"
+
+@implementation PriorityTextSplitterTest
+
+- (void)testSplit_empty
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@""];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", result.text, @"text should be blank");
+}
+
+- (void)testSplit_nil
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:nil];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", result.text, @"text should be blank");
+}
+
+- (void)testSplit_withPriority
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@"(A) test"];
+	STAssertEquals(PriorityA, result.priority.name, @"priority should be A");
+	STAssertEqualObjects(@"test", result.text, @"text should be \"test\"");
+}
+
+- (void)testSplit_withPrependedDate
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@"2011-01-02 test"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"2011-01-02 test", result.text, @"text should be \"test\"");
+}
+
+- (void)testSplit_withPriorityAndPrependedDate
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@"(A) 2011-01-02 test"];
+	STAssertEquals(PriorityA, result.priority.name, @"priority should be A");
+	STAssertEqualObjects(@"2011-01-02 test", result.text, @"text should be \"test\"");
+}
+
+- (void)testSplit_dateInterspersedInText
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@"Call Mom 2011-03-02"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"Call Mom 2011-03-02", result.text, @"text should be \"Call Mom 2011-03-02\"");
+}
+
+- (void)testSplit_missingSpace
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@"(A)2011-01-02 test"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"(A)2011-01-02 test", result.text, @"text should be \"(A)2011-01-02 test\"");
+}
+
+- (void)testSplit_outOfOrder
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@"2011-01-02 (A) test"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"2011-01-02 (A) test", result.text, @"text should be \"(A) test\"");
+}
+
+- (void)testSplit_completed
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@"x 2011-01-02 test 123"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"x 2011-01-02 test 123", result.text, @"text should be \"test 123\"");
+}
+
+- (void)testSplit_completedWithPrependedDate
+{
+	PriorityTextSplitter* result = [PriorityTextSplitter split:@"x 2011-01-02 2011-01-01 test 123"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"x 2011-01-02 2011-01-01 test 123", result.text, @"text should be \"test 123\"");
+}
+
+@end

--- a/Todo-txt-unit-tests/ProjectParserTest.h
+++ b/Todo-txt-unit-tests/ProjectParserTest.h
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface ProjectParserTest : SenTestCase
+
+@end

--- a/Todo-txt-unit-tests/ProjectParserTest.m
+++ b/Todo-txt-unit-tests/ProjectParserTest.m
@@ -1,0 +1,99 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "ProjectParserTest.h"
+#import "ProjectParser.h"
+
+@implementation ProjectParserTest
+
+- (void)test_empty
+{
+    NSString *input = @"";
+	NSArray *strings = [ProjectParser parse:input];
+	STAssertEqualObjects([NSArray array], strings, @"Should be empty");
+}
+
+- (void)test_nil
+{
+    NSString *input = nil;
+	NSArray *strings = [ProjectParser parse:input];
+	STAssertEqualObjects([NSArray array], strings, @"Should be empty");
+}
+
+- (void)test_withoutProject
+{
+    NSString *input = @"a simple string";
+	NSArray *strings = [ProjectParser parse:input];
+	STAssertEqualObjects([NSArray array], strings, @"Should be empty");
+}
+
+- (void)test_withProject
+{
+    NSString *input = @"a simple +string";
+	NSArray *strings = [ProjectParser parse:input];
+	STAssertEquals(1U, strings.count, @"Should be one match");
+	STAssertTrue([strings containsObject:@"string"], @"should contain \"string\"");
+}
+
+- (void)test_withMultipleProjects
+{
+    NSString *input = @"a simple +string +test";
+	NSArray *strings = [ProjectParser parse:input];
+	STAssertEquals(2U, strings.count, @"Should be two matches");
+	STAssertTrue([strings containsObject:@"string"], @"should contain \"string\"");
+	STAssertTrue([strings containsObject:@"test"], @"should contain \"test\"");
+}
+
+- (void)test_withInterspersedProjects
+{
+    NSString *input = @"+more complex +case with a +string +test";
+	NSArray *strings = [ProjectParser parse:input];
+	STAssertEquals(4U, strings.count, @"Should be four matches");
+	STAssertTrue([strings containsObject:@"more"], @"should contain \"more\"");
+	STAssertTrue([strings containsObject:@"case"], @"should contain \"case\"");
+	STAssertTrue([strings containsObject:@"string"], @"should contain \"string\"");
+	STAssertTrue([strings containsObject:@"test"], @"should contain \"test\"");
+}
+
+@end

--- a/Todo-txt-unit-tests/SortTest.h
+++ b/Todo-txt-unit-tests/SortTest.h
@@ -1,0 +1,52 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface SortTest : SenTestCase {
+
+	NSArray *unsortedTasks;
+}
+
+@end

--- a/Todo-txt-unit-tests/SortTest.m
+++ b/Todo-txt-unit-tests/SortTest.m
@@ -1,0 +1,124 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "SortTest.h"
+#import "Task.h"
+#import "Sort.h"
+
+
+@implementation SortTest
+
+
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+	unsortedTasks = [[NSArray arrayWithObjects:
+					 [[[Task alloc] initWithId:1 withRawText:@"(E) a test task"] autorelease],
+					 [[[Task alloc] initWithId:55 withRawText:@"z ultimate task"] autorelease],
+					 [[[Task alloc] initWithId:99 withRawText:@"(A) awesome task"] autorelease],
+					 [[[Task alloc] initWithId:5 withRawText:@"A capitalized task"] autorelease],
+					 [[[Task alloc] initWithId:9999 withRawText:@"x a completed task"] autorelease],
+					  nil] retain];
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+	[unsortedTasks release];
+    
+    [super tearDown];
+}
+
+- (void)testSort_priority
+{
+	Sort *sort = [Sort byName:SortPriority];
+	NSArray *sortedTasks = [unsortedTasks sortedArrayUsingSelector:sort.comparator];
+	
+	STAssertEquals(99U, [[sortedTasks objectAtIndex:0] taskId], @"item out of order");
+	STAssertEquals(1U, [[sortedTasks objectAtIndex:1] taskId], @"item out of order");
+	STAssertEquals(5U, [[sortedTasks objectAtIndex:2] taskId], @"item out of order");
+	STAssertEquals(55U, [[sortedTasks objectAtIndex:3] taskId], @"item out of order");
+	STAssertEquals(9999U, [[sortedTasks objectAtIndex:4] taskId], @"item out of order");
+}
+
+- (void)testSort_idDescending
+{
+	Sort *sort = [Sort byName:SortIdDescending];
+	NSArray *sortedTasks = [unsortedTasks sortedArrayUsingSelector:sort.comparator];
+	
+	STAssertEquals(9999U, [[sortedTasks objectAtIndex:0] taskId], @"item out of order");
+	STAssertEquals(99U, [[sortedTasks objectAtIndex:1] taskId], @"item out of order");
+	STAssertEquals(55U, [[sortedTasks objectAtIndex:2] taskId], @"item out of order");
+	STAssertEquals(5U, [[sortedTasks objectAtIndex:3] taskId], @"item out of order");
+	STAssertEquals(1U, [[sortedTasks objectAtIndex:4] taskId], @"item out of order");
+}
+
+- (void)testSort_idAscending
+{
+	Sort *sort = [Sort byName:SortIdAscending];
+	NSArray *sortedTasks = [unsortedTasks sortedArrayUsingSelector:sort.comparator];
+	
+	STAssertEquals(1U, [[sortedTasks objectAtIndex:0] taskId], @"item out of order");
+	STAssertEquals(5U, [[sortedTasks objectAtIndex:1] taskId], @"item out of order");
+	STAssertEquals(55U, [[sortedTasks objectAtIndex:2] taskId], @"item out of order");
+	STAssertEquals(99U, [[sortedTasks objectAtIndex:3] taskId], @"item out of order");
+	STAssertEquals(9999U, [[sortedTasks objectAtIndex:4] taskId], @"item out of order");
+}
+
+- (void)testSort_textAscending
+{
+	Sort *sort = [Sort byName:SortTextAscending];
+	NSArray *sortedTasks = [unsortedTasks sortedArrayUsingSelector:sort.comparator];
+	
+	STAssertEquals(5U, [[sortedTasks objectAtIndex:0] taskId], @"item out of order");
+	STAssertEquals(9999U, [[sortedTasks objectAtIndex:1] taskId], @"item out of order");
+	STAssertEquals(1U, [[sortedTasks objectAtIndex:2] taskId], @"item out of order");
+	STAssertEquals(99U, [[sortedTasks objectAtIndex:3] taskId], @"item out of order");
+	STAssertEquals(55U, [[sortedTasks objectAtIndex:4] taskId], @"item out of order");
+}
+
+@end

--- a/Todo-txt-unit-tests/StringsTest.h
+++ b/Todo-txt-unit-tests/StringsTest.h
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface StringsTest : SenTestCase
+
+@end

--- a/Todo-txt-unit-tests/StringsTest.m
+++ b/Todo-txt-unit-tests/StringsTest.m
@@ -1,0 +1,140 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "StringsTest.h"
+#import "Strings.h"
+
+@implementation StringsTest
+
+- (void)testInsertPadded_nil
+{
+    STAssertEqualObjects(@"thistest", [Strings insertPaddedString:@"thistest" atRange:NSMakeRange(4, 0) withString:nil], @"Nil argument should not change original string");
+}
+
+- (void)testInsertPadded_blank
+{
+    STAssertEqualObjects(@"thistest", [Strings insertPaddedString:@"thistest" atRange:NSMakeRange(4, 0) withString:@""], @"Blank argument should not change original string");
+}
+
+- (void)testInsertPadded_invalidInsertionPoint_tooSmall
+{
+    STAssertThrows([Strings insertPaddedString:@"thistest" atRange:NSMakeRange(-1, 0) withString:@"is"], @"NEgative insertion point should throw an exception");
+}
+
+- (void)testInsertPadded_invalidInsertionPoint_toolarge
+{
+    STAssertThrows([Strings insertPaddedString:@"thistest" atRange:NSMakeRange(99, 0) withString:@"is"], @"Insertion point past the end of the string should throw an exception");
+}
+
+- (void)testInsertPadded_simple
+{
+    STAssertEqualObjects(@"this is test", [Strings insertPaddedString:@"thistest" atRange:NSMakeRange(4, 0) withString:@"is"], @"Simple insertion failed");
+}
+
+- (void)testInsertPadded_simpleBegin
+{
+    STAssertEqualObjects(@"is thistest", [Strings insertPaddedString:@"thistest" atRange:NSMakeRange(0, 0) withString:@"is"], @"Simple insertion at beginning failed");
+}
+
+- (void)testInsertPadded_simpleEnd
+{
+    STAssertEqualObjects(@"thistest is ", [Strings insertPaddedString:@"thistest" atRange:NSMakeRange(8, 0) withString:@"is"], @"Simple insertion at end failed");
+}
+
+- (void)testInsertPadded_prepadded
+{
+    STAssertEqualObjects(@"this is test", [Strings insertPaddedString:@"this test" atRange:NSMakeRange(4, 0) withString:@"is"], @"Prepadded insertion failed");
+}
+
+- (void)testInsertPadded_prepaddedBegin
+{
+    STAssertEqualObjects(@"is this test", [Strings insertPaddedString:@" this test" atRange:NSMakeRange(0, 0) withString:@"is"], @"Prepadded insertion at beginning failed");
+}
+
+- (void)testInsertPadded_prepaddedEnd1
+{
+    STAssertEqualObjects(@"this test is ", [Strings insertPaddedString:@"this test " atRange:NSMakeRange(9, 0) withString:@"is"], @"Prepadded insertion at end failed");
+}
+
+- (void)testInsertPadded_prepaddedEnd2
+{
+    STAssertEqualObjects(@"this test is ", [Strings insertPaddedString:@"this test " atRange:NSMakeRange(10, 0) withString:@"is"], @"Prepadded insertion at end failed");
+}
+
+- (void)testCalculate_nilPrior
+{
+    STAssertEquals(NSMakeRange(7, 0), [Strings calculateSelectedRange:NSMakeRange(0, 0)	oldText:nil newText:@"123test"], @"Selected Range with nil Prior text should be length of new string");
+}
+
+- (void)testCalculate_nilNew
+{
+    STAssertEquals(NSMakeRange(0, 0), [Strings calculateSelectedRange:NSMakeRange(0, 0)	oldText:@"test" newText:nil], @"Selected Range with nil Prior text should be 0");
+}
+
+- (void)testCalculate_simpleBegin
+{
+    STAssertEquals(NSMakeRange(3, 0), [Strings calculateSelectedRange:NSMakeRange(0, 0)	oldText:@"test" newText:@"123test"], @"Selected Range should be 3");
+}
+
+- (void)testCalculate_simpleEnd
+{
+    STAssertEquals(NSMakeRange(7, 0), [Strings calculateSelectedRange:NSMakeRange(4, 0)	oldText:@"test" newText:@"123test"], @"Selected Range should be 7");
+}
+
+- (void)testCalculate_emptyPrior
+{
+    STAssertEquals(NSMakeRange(7, 0), [Strings calculateSelectedRange:NSMakeRange(0, 0)	oldText:@"" newText:@"123test"], @"Selected Range with empty Prior text should be length of new string");
+}
+
+- (void)testCalculate_emptyNew
+{
+    STAssertEquals(NSMakeRange(0, 0), [Strings calculateSelectedRange:NSMakeRange(0, 0)	oldText:@"test" newText:@""], @"Selected Range with nil Prior text should be 0");
+}
+
+- (void)testCalculate_nonsense1
+{
+    STAssertEquals(NSMakeRange(7, 0), [Strings calculateSelectedRange:NSMakeRange(99, 0) oldText:@"test" newText:@"test123"], @"Selected Range with bogus prior range should be length of new string");
+}
+
+@end

--- a/Todo-txt-unit-tests/TaskTest.h
+++ b/Todo-txt-unit-tests/TaskTest.h
@@ -42,36 +42,8 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#import "Todo_txt_unit_tests.h"
-#import "TaskUtil.h"
+#import <SenTestingKit/SenTestingKit.h>
 
-@implementation Todo_txt_unit_tests
-
-- (void)setUp
-{
-    [super setUp];
-    
-    // Set-up code here.
-}
-
-- (void)tearDown
-{
-    // Tear-down code here.
-    
-    [super tearDown];
-}
-
-- (void)testHasContext
-{
-	STAssertFalse([TaskUtil taskHasContext:@"" context:@"home"], @"context in empty string");
-	STAssertFalse([TaskUtil taskHasContext:@"hi @home" context:@"work"], @"work context in hi @home");
-	STAssertTrue([TaskUtil taskHasContext:@"hi @home" context:@"home"], @"context in hi @home");
-}
-
-- (void)testHasProject
-{
-	STAssertFalse([TaskUtil taskHasProject:@"" project:@"reorganize"], @"project in empty string");
-	STAssertTrue([TaskUtil taskHasProject:@"hi +reorganize" project:@"reorganize"], @"project in hi +reorganize");
-}
+@interface TaskTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/TaskTest.m
+++ b/Todo-txt-unit-tests/TaskTest.m
@@ -1,0 +1,1075 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "TaskTest.h"
+#import "Task.h"
+#import "Util.h"
+
+@implementation TaskTest
+
+- (void)testConstructor_simple
+{
+	NSString *input = @"A Simple test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_simple_prependDate
+{
+	NSString *input = @"A Simple test with no curve balls";
+	NSDate *date = [Util dateFromString:@"20110228" withFormat:@"yyyyMMdd"];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input withDefaultPrependedDate:date] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"2011-02-28", task.prependedDate, @"prependedDate should be 2011-11-28");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(@"2011-02-28 A Simple test with no curve balls", task.inFileFormat, @"inFileFormat should be \"2011-02-28 A Simple test with no curve balls\"");
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withPriority
+{
+	NSString *input = @"(A) A priority test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.originalText, @"originalText should be \"A priority test with no curve balls\"");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.text, @"text should be \"A priority test with no curve balls\"");
+	STAssertEquals([Priority byName:PriorityA], task.originalPriority, @"originalPriority should be A");
+	STAssertEquals([Priority byName:PriorityA], task.priority, @"priority should be A");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.inScreenFormat, @"inScreenFormat should be \"A priority test with no curve balls\"");
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withPrependedDate
+{
+	NSString *input = @"2011-11-28 A priority test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.originalText, @"originalText should be \"A priority test with no curve balls\"");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.text, @"text should be \"A priority test with no curve balls\"");
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"2011-11-28", task.prependedDate, @"prependedDate should be 2011-11-28");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.inScreenFormat, @"inScreenFormat should be \"A priority test with no curve balls\"");
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withPrependedDate_prependDate
+{
+	NSString *input = @"2011-11-28 A priority test with no curve balls";
+	NSDate *date = [Util dateFromString:@"20110228" withFormat:@"yyyyMMdd"];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input withDefaultPrependedDate:date] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.originalText, @"originalText should be \"A priority test with no curve balls\"");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.text, @"text should be \"A priority test with no curve balls\"");
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"2011-11-28", task.prependedDate, @"prependedDate should be 2011-11-28");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(@"A priority test with no curve balls", task.inScreenFormat, @"inScreenFormat should be \"A priority test with no curve balls\"");
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withContext
+{
+	NSString *input = @"A simple test @phone";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEquals(1U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"phone"], @"Task should contain context \"phone\"");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withMultipleContexts
+{
+	NSString *input = @"A simple test with @multiple @contexts @phone";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertTrue([task.contexts containsObject:@"phone"], @"Task should contain context \"phone\"");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withInterspersedContexts
+{
+	NSString *input = @"@simple test @with multiple contexts @phone";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"simple"], @"Task should contain context \"simple\"");
+	STAssertTrue([task.contexts containsObject:@"with"], @"Task should contain context \"with\"");
+	STAssertTrue([task.contexts containsObject:@"phone"], @"Task should contain context \"phone\"");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withProject
+{
+	NSString *input = @"A simple test +myproject";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEquals(1U, task.projects.count, @"should be 1 project");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withMultipleProjects
+{
+	NSString *input = @"A simple test with +multiple +projects +associated";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEquals(3U, task.projects.count, @"should be 3 projects");
+	STAssertTrue([task.projects containsObject:@"multiple"], @"Task should contain project \"multiple\"");
+	STAssertTrue([task.projects containsObject:@"projects"], @"Task should contain project \"projects\"");
+	STAssertTrue([task.projects containsObject:@"associated"], @"Task should contain project \"associated\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withInterspersedProjects
+{
+	NSString *input = @"A +simple test +with +multiple projects +myproject";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEquals(4U, task.projects.count, @"should be 4 projects");
+	STAssertTrue([task.projects containsObject:@"simple"], @"Task should contain project \"simple\"");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"multiple"], @"Task should contain project \"multiple\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withLink
+{
+	NSString *input = @"A simple test with an http://www.url.com";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	//FIXME: No support for links yet
+	//STAssertEquals(1U, task.links.count, @"should be 1 link");
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.url.com"]], @"Task should contain link \"http://www.url.com\"");	
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withMultipleLinks
+{
+	NSString *input = @"A simple test with two http://www.urls.com http://www.another.one";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	//FIXME: No support for links yet
+	//STAssertEquals(2U, task.links.count, @"should be 2 links");
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.url.com"]], @"Task should contain link \"http://www.url.com\"");	
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.another.one"]], @"Task should contain link \"http://www.another.one\"");	
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_withInterspersedLinks
+{
+	NSString *input = @"A simple https://ww.url.com test with two http://www.urls.com http://www.another.one";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	//FIXME: No support for links yet
+	//STAssertEquals(3U, task.links.count, @"should be 3 links");
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.url.com"]], @"Task should contain link \"http://www.url.com\"");	
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.urls.com"]], @"Task should contain link \"http://www.urls.com\"");	
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.another.one"]], @"Task should contain link \"http://www.another.one\"");	
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_complex
+{
+	
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject and links http://www.link.com";
+	NSString *priority = @"D";
+	NSString *date = @"2011-12-01";
+	NSString *input = [NSString stringWithFormat:@"(%@) %@ %@", priority, date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority byCode:priority], task.originalPriority, @"originalPriority should be %@", priority);
+	STAssertEquals([Priority byCode:priority], task.priority, @"priority should be %@", priority);
+	STAssertEqualObjects(date, task.prependedDate, @"prependedDate should be %@", date);
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"complex"], @"Task should contain context \"complex\"");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	//FIXME: No support for links yet
+	//STAssertEquals(1U, task.links.count, @"should be 1 link");
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.link.com"]], @"Task should contain link \"http://www.link.com\"");	
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_email
+{
+	NSString *input = @"Email me@steveh.ca about unit testing";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	//FIXME: No support for links yet
+	//STAssertEqualObjects([NSArray array], task.links, @"links should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_empty
+{
+	NSString *input = @"";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	//FIXME: No support for links yet
+	//STAssertEqualObjects([NSArray array], task.links, @"links should be empty");
+	STAssertTrue(task.deleted, @"Task should be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_nil
+{
+	Task *task = [[[Task alloc] initWithId:1 withRawText:nil] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(@"", task.originalText, @"originalText should be empty");
+	STAssertEqualObjects(@"", task.text, @"text should be empty");
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	//FIXME: No support for links yet
+	//STAssertEqualObjects([NSArray array], task.links, @"links should be empty");
+	STAssertTrue(task.deleted, @"Task should be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(@"", task.inScreenFormat, @"inScreenFormat should be empty");
+	STAssertEqualObjects(@"", task.inFileFormat, @"inFileFormat should be empty");
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testConstructor_completedTask
+{
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject with http://www.link.com";
+	NSString *date = @"2011-02-28";
+	NSString *input = [NSString stringWithFormat:@"x %@ %@", date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"complex"], @"Task should contain context \"complex\"");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	//FIXME: No support for links yet
+	//STAssertEquals(1U, task.links.count, @"should be 1 link");
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.link.com"]], @"Task should contain link \"http://www.link.com\"");	
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertTrue(task.completed, @"Task should be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(date, task.completionDate, @"completionDate should be %@", date);
+}
+
+- (void)testConstructor_completedTask_upperCase
+{
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject with http://www.link.com";
+	NSString *date = @"2011-02-28";
+	NSString *input = [NSString stringWithFormat:@"X %@ %@", date, text];
+	NSString *expected = [NSString stringWithFormat:@"x %@ %@", date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"complex"], @"Task should contain context \"complex\"");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	//FIXME: No support for links yet
+	//STAssertEquals(1U, task.links.count, @"should be 1 link");
+	//STAssertTrue([task.links containsObject:[NSURL URLWithString:@"http://www.link.com"]], @"Task should contain link \"http://www.link.com\"");	
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertTrue(task.completed, @"Task should be completed");
+	STAssertEqualObjects(expected, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(expected, task.inFileFormat, @"inFileFormat should be %@", input);
+	STAssertEqualObjects(date, task.completionDate, @"completionDate should be %@", date);
+}
+
+- (void)testEqualsAndHashCode_simple {
+	NSString *input = @"(D) 2011-12-01 A @complex test with @multiple projects and @contexts myproject";
+	Task *task1 = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	Task *task2 = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertTrue([task1 isEqual:task1], @"task1 should equal itself");
+	STAssertTrue([task2 isEqual:task2], @"task2 should equal itself");
+	STAssertTrue([task1 isEqual:task2], @"task1 should equal task2");
+	STAssertTrue([task2 isEqual:task1], @"task2 should equal task1");
+	STAssertEquals(task1.hash, task2.hash, @"task1 should equal itself");
+}
+
+- (void)testCopyInto {
+	NSString *input1 = @"(D) 2011-12-01 A @complex test with @multiple projects and @contexts myproject";
+	NSString *input2 = @"A simple text input";
+	Task *task1 = [[[Task alloc] initWithId:1 withRawText:input1] autorelease];
+	Task *task2 = [[[Task alloc] initWithId:2 withRawText:input2] autorelease];
+	[task1 copyInto:task2];
+	
+	STAssertEquals(task1.taskId, task2.taskId, @"Should have same taskID");
+	STAssertFalse([task1.originalText isEqualToString:task2.originalText], @"Should have same originalText");
+	STAssertEqualObjects(@"A @complex test with @multiple projects and @contexts myproject", task1.originalText, @"task1 originalText should be \"A @complex test with @multiple projects and @contexts myproject\"");
+	STAssertEqualObjects(@"A simple text input", task2.originalText, @"task2 originalText should be \"A simple text input\"");
+	STAssertEqualObjects(task1.text, task2.text, @"Texts should be equal");
+	STAssertFalse(task1.originalPriority == task2.originalPriority, @"Should have same originalPriority");
+	STAssertEquals([Priority byName:PriorityD], task1.originalPriority, @"task1 originalPriority should be D");
+	STAssertEquals([Priority NONE], task2.originalPriority, @"task2 originalPriority should be NONE");
+	STAssertEquals(task1.priority, task2.priority, @"Should have same priority");
+	STAssertEqualObjects(task1.prependedDate, task2.prependedDate, @"Should have same prependedDate");
+	STAssertEqualObjects(task1.contexts, task2.contexts, @"Should have same contexts");
+	STAssertEqualObjects(task1.projects, task2.projects, @"Should have same projects");
+	STAssertEquals(task1.deleted, task2.deleted, @"Should have same deleted");
+	STAssertEquals(task1.completed, task2.completed, @"Should have same completed");
+	STAssertEqualObjects(task1, task2, @"Tasks should be equal");
+	STAssertEqualObjects(@"A @complex test with @multiple projects and @contexts myproject", task1.inScreenFormat, @"task1 inScreenFormat should be \"A @complex test with @multiple projects and @contexts myproject\"");
+	STAssertEqualObjects(@"A @complex test with @multiple projects and @contexts myproject", task2.inScreenFormat, @"task2 inScreenFormat should be \"A @complex test with @multiple projects and @contexts myproject\"");
+	STAssertEqualObjects(input1, task1.inFileFormat, @"task1 inFileFormat should be \"%@\"", input1);
+	STAssertEqualObjects(input1, task2.inFileFormat, @"task2 inFileFormat should be \"%@\"", input1);
+	STAssertEqualObjects(@"", task1.completionDate, @"task1 completionDate should be blank");
+	STAssertEqualObjects(task1.completionDate, task2.completionDate, @"Should have same completionDate");
+}
+
+- (void)testMarkComplete
+{
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject";
+	NSString *priority = @"D";
+	NSString *date = @"2011-02-28";
+	NSString *input = [NSString stringWithFormat:@"(%@) %@ %@", priority, date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	NSString *completedDate = @"2011-02-28"; 
+	
+	NSString *completedText = [NSString stringWithFormat:@"x %@ %@ %@", completedDate, date, text];
+	
+	[task markComplete:[Util dateFromString:completedDate withFormat:@"yyyy-MM-dd"]];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority byCode:priority], task.originalPriority, @"originalPriority should be %@", priority);
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(date, task.prependedDate, @"prependedDate should be %@", date);
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"complex"], @"Task should contain context \"complex\"");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertTrue(task.completed, @"Task should be completed");
+	STAssertEqualObjects(completedText, task.inScreenFormat, @"inScreenFormat should be %@", completedText);
+	STAssertEqualObjects(completedText, task.inFileFormat, @"inFileFormat should be %@", completedText);
+	STAssertEqualObjects(completedDate, task.completionDate, @"completionDate should be %@", completedDate);
+}
+
+- (void)testMarkComplete_twice
+{
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject";
+	NSString *priority = @"D";
+	NSString *date = @"2011-02-28";
+	NSString *input = [NSString stringWithFormat:@"(%@) %@ %@", priority, date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	NSString *completedDate = @"2011-02-28"; 
+	
+	NSString *completedText = [NSString stringWithFormat:@"x %@ %@ %@", completedDate, date, text];
+	
+	[task markComplete:[Util dateFromString:completedDate withFormat:@"yyyy-MM-dd"]];
+	[task markComplete:[Util dateFromString:completedDate withFormat:@"yyyy-MM-dd"]];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority byCode:priority], task.originalPriority, @"originalPriority should be %@", priority);
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(date, task.prependedDate, @"prependedDate should be %@", date);
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"complex"], @"Task should contain context \"complex\"");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertTrue(task.completed, @"Task should be completed");
+	STAssertEqualObjects(completedText, task.inScreenFormat, @"inScreenFormat should be %@", completedText);
+	STAssertEqualObjects(completedText, task.inFileFormat, @"inFileFormat should be %@", completedText);
+	STAssertEqualObjects(completedDate, task.completionDate, @"completionDate should be %@", completedDate);
+}
+
+- (void)testMarkIncomplete
+{
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject";
+	NSString *date = @"2011-02-28";
+	NSString *input = [NSString stringWithFormat:@"x %@ %@", date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+		
+	[task markIncomplete];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"complex"], @"Task should contain context \"complex\"");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", text);
+	STAssertEqualObjects(text, task.inFileFormat, @"inFileFormat should be %@", text);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testMarkIncomplete_twice
+{
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject";
+	NSString *date = @"2011-02-28";
+	NSString *input = [NSString stringWithFormat:@"x %@ %@", date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task markIncomplete];
+	[task markIncomplete];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"complex"], @"Task should contain context \"complex\"");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", text);
+	STAssertEqualObjects(text, task.inFileFormat, @"inFileFormat should be %@", text);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testMarkIncomplete_withPrependedDate
+{
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject";
+	NSString *date = @"2011-02-17";
+	NSString *completedDate = @"2011-02-28";
+	NSString *input = [NSString stringWithFormat:@"x %@ %@ %@", completedDate, date, text];
+	NSString *incompleteText = [NSString stringWithFormat:@"%@ %@", date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task markIncomplete];
+	[task markIncomplete];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(date, task.prependedDate, @"prependedDate should be %@", date);
+	STAssertEquals(3U, task.contexts.count, @"should be 3 contexts");
+	STAssertTrue([task.contexts containsObject:@"complex"], @"Task should contain context \"complex\"");
+	STAssertTrue([task.contexts containsObject:@"multiple"], @"Task should contain context \"multiple\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"with"], @"Task should contain project \"with\"");
+	STAssertTrue([task.projects containsObject:@"myproject"], @"Task should contain project \"myproject\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", text);
+	STAssertEqualObjects(incompleteText, task.inFileFormat, @"inFileFormat should be %@", text);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testDelete_simple {
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject";
+	NSString *priority = @"D";
+	NSString *date = @"2011-12-01";
+	NSString *input = [NSString stringWithFormat:@"(%@) %@ %@", priority, date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task deleteTask];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(@"", task.text, @"text should be blank");
+	STAssertEquals([Priority byCode:priority], task.originalPriority, @"originalPriority should be %@", priority);
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertTrue(task.deleted, @"Task should be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(@"", task.inScreenFormat, @"inScreenFormat should be blank");
+	STAssertEqualObjects(@"", task.inFileFormat, @"inFileFormat should be blank");
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testDelete_twice {
+	NSString *text = @"A @complex test +with @multiple projects and @contexts +myproject";
+	NSString *priority = @"D";
+	NSString *date = @"2011-12-01";
+	NSString *input = [NSString stringWithFormat:@"(%@) %@ %@", priority, date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task deleteTask];
+	[task deleteTask];
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(@"", task.text, @"text should be blank");
+	STAssertEquals([Priority byCode:priority], task.originalPriority, @"originalPriority should be %@", priority);
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertTrue(task.deleted, @"Task should be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(@"", task.inScreenFormat, @"inScreenFormat should be blank");
+	STAssertEqualObjects(@"", task.inFileFormat, @"inFileFormat should be blank");
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testInFileFormat_simple {
+	NSString *input = @"A Simple test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withPriority {
+	NSString *input = @"(A) Simple test with a priority";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withPrependedDate {
+	NSString *input = @"2011-01-29 Simple test with a prepended date";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withPriorityAndPrependedDate {
+	NSString *input = @"(B) 2011-01-29 Simple test with a priority and a prepended date";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withContext {
+	NSString *input = @"Simple test with a context @home";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withMultipleContexts {
+	NSString *input = @"Simple test @phone @home";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withInterspersedContexts {
+	NSString *input = @"Simple @phone test @home";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withProject {
+	NSString *input = @"Simple test with a +project";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withMultipleProjects {
+	NSString *input = @"Simple test +phone +home";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_withInterspersedProjects {
+	NSString *input = @"+Simple phone +test home";
+	Task *task = [[[Task alloc] initWithId:0 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_complex {
+	NSString *input = @"(D) 2011-12-01 A @complex test +with @multiple +projects and @contexts +myproject";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_empty {
+	NSString *input = @"";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(input, task.inFileFormat, @"inFileFormat shoud be \"%@\"", input);
+}
+
+- (void)testInFileFormat_nil {
+	NSString *input = nil;
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	STAssertEqualObjects(@"", task.inFileFormat, @"inFileFormat shoud be nil");
+}
+
+- (void)testSetPriority_noExisting {
+	NSString *input = @"A Simple test with no curve balls";
+	NSString *priority = @"C";
+	NSString *expected = [NSString stringWithFormat:@"(%@) %@", priority, input];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	task.priority = [Priority byCode:priority];					 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(input, task.text, @"text should be %@", input);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority byCode:priority], task.priority, @"priority should be C");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(input, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(expected, task.inFileFormat, @"inFileFormat should be %@", expected);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testSetPriority_noExistingWithPrependedDate {
+	NSString *text = @"A Simple test with no curve balls";
+	NSString *priority = @"B";
+	NSString *date = @"2011-11-01";
+	NSString *expected = [NSString stringWithFormat:@"(%@) %@ %@", priority, date, text];
+	NSString *input = [NSString stringWithFormat:@"%@ %@", date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	task.priority = [Priority byCode:priority];					 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority byCode:priority], task.priority, @"priority should be C");
+	STAssertEqualObjects(date, task.prependedDate, @"prependedDate should be %@", date);
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", input);
+	STAssertEqualObjects(expected, task.inFileFormat, @"inFileFormat should be %@", expected);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testSetPriority_existing {
+	NSString *text = @"A Simple test with no curve balls";
+	NSString *originalPriority = @"A";
+	NSString *priority = @"C";
+	NSString *expected = [NSString stringWithFormat:@"(%@) %@", priority, text];
+	NSString *input = [NSString stringWithFormat:@"(%@) %@", originalPriority, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	task.priority = [Priority byCode:priority];					 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority byCode:originalPriority], task.originalPriority, @"originalPriority should be A");
+	STAssertEquals([Priority byCode:priority], task.priority, @"priority should be C");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", text);
+	STAssertEqualObjects(expected, task.inFileFormat, @"inFileFormat should be %@", expected);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testSetPriority_existingWithPrependedDate {
+	NSString *text = @"A Simple test with no curve balls";
+	NSString *originalPriority = @"A";
+	NSString *priority = @"C";
+	NSString *date = @"2011-11-01";
+	NSString *expected = [NSString stringWithFormat:@"(%@) %@ %@", priority, date, text];
+	NSString *input = [NSString stringWithFormat:@"(%@) %@ %@", originalPriority, date, text];
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	task.priority = [Priority byCode:priority];					 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(text, task.originalText, @"originalText should be %@", text);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority byCode:originalPriority], task.originalPriority, @"originalPriority should be A");
+	STAssertEquals([Priority byCode:priority], task.priority, @"priority should be C");
+	STAssertEqualObjects(date, task.prependedDate, @"prependedDate should be %@", date);
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", text);
+	STAssertEqualObjects(expected, task.inFileFormat, @"inFileFormat should be %@", expected);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testUpdate_simpleToSimple {
+	NSString *expectedResult = @"Another simple test with no curve balls";
+	NSString *input = @"A Simple test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task update:expectedResult];				 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(expectedResult, task.text, @"text should be %@", expectedResult);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(expectedResult, task.inScreenFormat, @"inScreenFormat should be %@", expectedResult);
+	STAssertEqualObjects(expectedResult, task.inFileFormat, @"inFileFormat should be %@", expectedResult);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testUpdate_simpleToWithContexts {
+	NSString *expectedResult = @"Another simple @test with @contexts";
+	NSString *input = @"A Simple test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task update:expectedResult];				 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(expectedResult, task.text, @"text should be %@", expectedResult);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEquals(2U, task.contexts.count, @"should be 2 contexts");
+	STAssertTrue([task.contexts containsObject:@"test"], @"Task should contain context \"test\"");
+	STAssertTrue([task.contexts containsObject:@"contexts"], @"Task should contain context \"contexts\"");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(expectedResult, task.inScreenFormat, @"inScreenFormat should be %@", expectedResult);
+	STAssertEqualObjects(expectedResult, task.inFileFormat, @"inFileFormat should be %@", expectedResult);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testUpdate_simpleToWithProjects {
+	NSString *expectedResult = @"Another simple +test with +projects";
+	NSString *input = @"A Simple test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task update:expectedResult];				 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(expectedResult, task.text, @"text should be %@", expectedResult);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEquals(2U, task.projects.count, @"should be 2 projects");
+	STAssertTrue([task.projects containsObject:@"test"], @"Task should contain projects \"test\"");
+	STAssertTrue([task.projects containsObject:@"projects"], @"Task should contain projects \"projects\"");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(expectedResult, task.inScreenFormat, @"inScreenFormat should be %@", expectedResult);
+	STAssertEqualObjects(expectedResult, task.inFileFormat, @"inFileFormat should be %@", expectedResult);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testUpdate_simpleToPriority {
+	NSString *text = @"Another simple test with no curve balls";
+	NSString *priority = @"A";
+	NSString *expectedResult = [NSString stringWithFormat:@"(%@) %@", priority, text];
+	NSString *input = @"A Simple test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task update:expectedResult];				 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority byCode:priority], task.priority, @"priority should be A");
+	STAssertEqualObjects(@"", task.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", text);
+	STAssertEqualObjects(expectedResult, task.inFileFormat, @"inFileFormat should be %@", expectedResult);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+- (void)testSetText_simpleToPrependedDate {
+	NSString *text = @"Another simple test with no curve balls";
+	NSString *date = @"2011-10-01";
+	NSString *expectedResult = [NSString stringWithFormat:@"%@ %@", date, text];
+	NSString *input = @"A Simple test with no curve balls";
+	Task *task = [[[Task alloc] initWithId:1 withRawText:input] autorelease];
+	
+	[task update:expectedResult];				 
+	
+	STAssertEquals(1U, task.taskId, @"Task ID should be 1");
+	STAssertEqualObjects(input, task.originalText, @"originalText should be %@", input);
+	STAssertEqualObjects(text, task.text, @"text should be %@", text);
+	STAssertEquals([Priority NONE], task.originalPriority, @"originalPriority should be NONE");
+	STAssertEquals([Priority NONE], task.priority, @"priority should be NONE");
+	STAssertEqualObjects(date, task.prependedDate, @"prependedDate should be %@", date);
+	STAssertEqualObjects([NSArray array], task.contexts, @"contexts should be empty");
+	STAssertEqualObjects([NSArray array], task.projects, @"projects should be empty");
+	STAssertFalse(task.deleted, @"Task should not be deleted");
+	STAssertFalse(task.completed, @"Task should not be completed");
+	STAssertEqualObjects(text, task.inScreenFormat, @"inScreenFormat should be %@", text);
+	STAssertEqualObjects(expectedResult, task.inFileFormat, @"inFileFormat should be %@", expectedResult);
+	STAssertEqualObjects(@"", task.completionDate, @"completionDate should be blank");
+}
+
+@end

--- a/Todo-txt-unit-tests/TaskUtilTest.h
+++ b/Todo-txt-unit-tests/TaskUtilTest.h
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface TaskUtilTest : SenTestCase
+
+@end

--- a/Todo-txt-unit-tests/TaskUtilTest.m
+++ b/Todo-txt-unit-tests/TaskUtilTest.m
@@ -1,0 +1,77 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "TaskUtilTest.h"
+#import "TaskUtil.h"
+
+@implementation TaskUtilTest
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+    
+    [super tearDown];
+}
+
+- (void)testHasContext
+{
+	STAssertFalse([TaskUtil taskHasContext:@"" context:@"home"], @"context in empty string");
+	STAssertFalse([TaskUtil taskHasContext:@"hi @home" context:@"work"], @"work context in hi @home");
+	STAssertTrue([TaskUtil taskHasContext:@"hi @home" context:@"home"], @"context in hi @home");
+}
+
+- (void)testHasProject
+{
+	STAssertFalse([TaskUtil taskHasProject:@"" project:@"reorganize"], @"project in empty string");
+	STAssertTrue([TaskUtil taskHasProject:@"hi +reorganize" project:@"reorganize"], @"project in hi +reorganize");
+}
+
+@end

--- a/Todo-txt-unit-tests/TextSplitterTest.h
+++ b/Todo-txt-unit-tests/TextSplitterTest.h
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface TextSplitterTest : SenTestCase
+
+@end

--- a/Todo-txt-unit-tests/TextSplitterTest.m
+++ b/Todo-txt-unit-tests/TextSplitterTest.m
@@ -1,0 +1,151 @@
+/**
+ * This file is part of Todo.txt Touch, an iOS app for managing your todo.txt file.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @copyright 2011 Todo.txt contributors (http://todotxt.com)
+ *  
+ * Dual-licensed under the GNU General Public License and the MIT License
+ *
+ * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license The MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "TextSplitterTest.h"
+#import "Priority.h"
+#import "TextSplitter.h"
+
+@implementation TextSplitterTest
+
+- (void)testSplit_empty
+{
+	TextSplitter* result = [TextSplitter split:@""];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", result.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects(@"", result.text, @"text should be blank");
+	STAssertFalse(result.completed, @"completed should be false");
+	STAssertEqualObjects(@"", result.completedDate, @"completedDate should be blank");
+}
+
+- (void)testSplit_nil
+{
+	TextSplitter* result = [TextSplitter split:nil];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", result.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects(@"", result.text, @"text should be blank");
+	STAssertFalse(result.completed, @"completed should be false");
+	STAssertEqualObjects(@"", result.completedDate, @"completedDate should be blank");
+}
+
+- (void)testSplit_withPriority
+{
+	TextSplitter* result = [TextSplitter split:@"(A) test"];
+	STAssertEquals(PriorityA, result.priority.name, @"priority should be A");
+	STAssertEqualObjects(@"", result.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects(@"test", result.text, @"text should be \"test\"");
+	STAssertFalse(result.completed, @"completed should be false");
+	STAssertEqualObjects(@"", result.completedDate, @"completedDate should be blank");
+}
+
+- (void)testSplit_withPrependedDate
+{
+	TextSplitter* result = [TextSplitter split:@"2011-01-02 test"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"2011-01-02", result.prependedDate, @"prependedDate should be 2011-01-02");
+	STAssertEqualObjects(@"test", result.text, @"text should be \"test\"");
+	STAssertFalse(result.completed, @"completed should be false");
+	STAssertEqualObjects(@"", result.completedDate, @"completedDate should be blank");
+}
+
+- (void)testSplit_withPriorityAndPrependedDate
+{
+	TextSplitter* result = [TextSplitter split:@"(A) 2011-01-02 test"];
+	STAssertEquals(PriorityA, result.priority.name, @"priority should be A");
+	STAssertEqualObjects(@"2011-01-02", result.prependedDate, @"prependedDate should be 2011-01-02");
+	STAssertEqualObjects(@"test", result.text, @"text should be \"test\"");
+	STAssertFalse(result.completed, @"completed should be false");
+	STAssertEqualObjects(@"", result.completedDate, @"completedDate should be blank");
+}
+
+- (void)testSplit_dateInterspersedInText
+{
+	TextSplitter* result = [TextSplitter split:@"Call Mom 2011-03-02"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", result.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects(@"Call Mom 2011-03-02", result.text, @"text should be \"Call Mom 2011-03-02\"");
+	STAssertFalse(result.completed, @"completed should be false");
+	STAssertEqualObjects(@"", result.completedDate, @"completedDate should be blank");
+}
+
+- (void)testSplit_missingSpace
+{
+	TextSplitter* result = [TextSplitter split:@"(A)2011-01-02 test"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", result.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects(@"(A)2011-01-02 test", result.text, @"text should be \"(A)2011-01-02 test\"");
+	STAssertFalse(result.completed, @"completed should be false");
+	STAssertEqualObjects(@"", result.completedDate, @"completedDate should be blank");
+}
+
+- (void)testSplit_outOfOrder
+{
+	TextSplitter* result = [TextSplitter split:@"2011-01-02 (A) test"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"2011-01-02", result.prependedDate, @"prependedDate should be 2011-01-02");
+	STAssertEqualObjects(@"(A) test", result.text, @"text should be \"(A) test\"");
+	STAssertFalse(result.completed, @"completed should be false");
+	STAssertEqualObjects(@"", result.completedDate, @"completedDate should be blank");
+}
+
+- (void)testSplit_completed
+{
+	TextSplitter* result = [TextSplitter split:@"x 2011-01-02 test 123"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"", result.prependedDate, @"prependedDate should be blank");
+	STAssertEqualObjects(@"test 123", result.text, @"text should be \"test 123\"");
+	STAssertTrue(result.completed, @"completed should be true");
+	STAssertEqualObjects(@"2011-01-02", result.completedDate, @"completedDate should be 2011-01-02");
+}
+
+- (void)testSplit_completedWithPrependedDate
+{
+	TextSplitter* result = [TextSplitter split:@"x 2011-01-02 2011-01-01 test 123"];
+	STAssertEqualObjects([Priority NONE], result.priority, @"priority should be NONE");
+	STAssertEqualObjects(@"2011-01-01", result.prependedDate, @"prependedDate should be 2011-01-01");
+	STAssertEqualObjects(@"test 123", result.text, @"text should be \"test 123\"");
+	STAssertTrue(result.completed, @"completed should be true");
+	STAssertEqualObjects(@"2011-01-02", result.completedDate, @"completedDate should be 2011-01-02");
+}
+
+@end

--- a/todo.txt-touch-ios.xcodeproj/project.pbxproj
+++ b/todo.txt-touch-ios.xcodeproj/project.pbxproj
@@ -115,6 +115,26 @@
 		88A5B6C314ADA91000EA6F70 /* PriorityTextSplitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 882B3E8A13EF47610085C888 /* PriorityTextSplitter.m */; };
 		88A91724146614920075B886 /* DropboxSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88A91723146614920075B886 /* DropboxSDK.framework */; };
 		88AAFC631419CB960062BBF6 /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 88AAFC621419CB960062BBF6 /* Icon@2x.png */; };
+		88DB7C0A14B2C760003A96F9 /* FilterFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BF114AFC3CE003A96F9 /* FilterFactory.m */; };
+		88DB7C0C14B2C760003A96F9 /* ByContextFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BF414B2A9F0003A96F9 /* ByContextFilter.m */; };
+		88DB7C0E14B2C760003A96F9 /* ByPriorityFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BF714B2B073003A96F9 /* ByPriorityFilter.m */; };
+		88DB7C1014B2C760003A96F9 /* ByProjectFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BFA14B2B319003A96F9 /* ByProjectFilter.m */; };
+		88DB7C1214B2C760003A96F9 /* ByTextFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BFD14B2B423003A96F9 /* ByTextFilter.m */; };
+		88DB7C1414B2C760003A96F9 /* AndFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C0014B2B9FB003A96F9 /* AndFilter.m */; };
+		88DB7C1614B2C760003A96F9 /* OrFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C0314B2BE68003A96F9 /* OrFilter.m */; };
+		88DB7C1814B2C760003A96F9 /* AndFilterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C0614B2C6A6003A96F9 /* AndFilterTest.m */; };
+		88DB7C1B14B2C786003A96F9 /* FilterFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BF114AFC3CE003A96F9 /* FilterFactory.m */; };
+		88DB7C1D14B2C786003A96F9 /* ByContextFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BF414B2A9F0003A96F9 /* ByContextFilter.m */; };
+		88DB7C1F14B2C786003A96F9 /* ByPriorityFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BF714B2B073003A96F9 /* ByPriorityFilter.m */; };
+		88DB7C2114B2C786003A96F9 /* ByProjectFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BFA14B2B319003A96F9 /* ByProjectFilter.m */; };
+		88DB7C2314B2C786003A96F9 /* ByTextFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7BFD14B2B423003A96F9 /* ByTextFilter.m */; };
+		88DB7C2514B2C786003A96F9 /* AndFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C0014B2B9FB003A96F9 /* AndFilter.m */; };
+		88DB7C2714B2C786003A96F9 /* OrFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C0314B2BE68003A96F9 /* OrFilter.m */; };
+		88DB7C2A14B3E87E003A96F9 /* ByContextFilterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C2914B3E87E003A96F9 /* ByContextFilterTest.m */; };
+		88DB7C2D14B3F140003A96F9 /* ByPriorityFilterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C2C14B3F140003A96F9 /* ByPriorityFilterTest.m */; };
+		88DB7C3014B3F5C1003A96F9 /* ByProjectFilterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C2F14B3F5C0003A96F9 /* ByProjectFilterTest.m */; };
+		88DB7C3314B3FDE9003A96F9 /* ByTextFilterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C3214B3FDE8003A96F9 /* ByTextFilterTest.m */; };
+		88DB7C3614B4056F003A96F9 /* OrFilterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB7C3514B4056E003A96F9 /* OrFilterTest.m */; };
 		88F043E2148879C1007C32DA /* SSTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 88334817146F5D4F009CBDE9 /* SSTextView.m */; };
 		88F1AB2A1412D5F100AB3D18 /* LoginScreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 88F1AB281412D5F100AB3D18 /* LoginScreenViewController.m */; };
 		88F1AB2B1412D5F100AB3D18 /* LoginScreenViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 88F1AB291412D5F100AB3D18 /* LoginScreenViewController.xib */; };
@@ -294,6 +314,33 @@
 		88A91723146614920075B886 /* DropboxSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = DropboxSDK.framework; sourceTree = "<group>"; };
 		88A91726146643B70075B886 /* DropboxApiKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DropboxApiKey.h; path = ../DropboxApiKey.h; sourceTree = "<group>"; };
 		88AAFC621419CB960062BBF6 /* Icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon@2x.png"; sourceTree = "<group>"; };
+		88DB7BEE14AFC0E2003A96F9 /* Filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Filter.h; path = Classes/Filter.h; sourceTree = "<group>"; };
+		88DB7BF014AFC3CD003A96F9 /* FilterFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FilterFactory.h; path = Classes/FilterFactory.h; sourceTree = "<group>"; };
+		88DB7BF114AFC3CE003A96F9 /* FilterFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FilterFactory.m; path = Classes/FilterFactory.m; sourceTree = "<group>"; };
+		88DB7BF314B2A9F0003A96F9 /* ByContextFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByContextFilter.h; path = Classes/ByContextFilter.h; sourceTree = "<group>"; };
+		88DB7BF414B2A9F0003A96F9 /* ByContextFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ByContextFilter.m; path = Classes/ByContextFilter.m; sourceTree = "<group>"; };
+		88DB7BF614B2B073003A96F9 /* ByPriorityFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByPriorityFilter.h; path = Classes/ByPriorityFilter.h; sourceTree = "<group>"; };
+		88DB7BF714B2B073003A96F9 /* ByPriorityFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ByPriorityFilter.m; path = Classes/ByPriorityFilter.m; sourceTree = "<group>"; };
+		88DB7BF914B2B318003A96F9 /* ByProjectFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByProjectFilter.h; path = Classes/ByProjectFilter.h; sourceTree = "<group>"; };
+		88DB7BFA14B2B319003A96F9 /* ByProjectFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ByProjectFilter.m; path = Classes/ByProjectFilter.m; sourceTree = "<group>"; };
+		88DB7BFC14B2B423003A96F9 /* ByTextFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByTextFilter.h; path = Classes/ByTextFilter.h; sourceTree = "<group>"; };
+		88DB7BFD14B2B423003A96F9 /* ByTextFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ByTextFilter.m; path = Classes/ByTextFilter.m; sourceTree = "<group>"; };
+		88DB7BFF14B2B9FA003A96F9 /* AndFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AndFilter.h; path = Classes/AndFilter.h; sourceTree = "<group>"; };
+		88DB7C0014B2B9FB003A96F9 /* AndFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AndFilter.m; path = Classes/AndFilter.m; sourceTree = "<group>"; };
+		88DB7C0214B2BE67003A96F9 /* OrFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OrFilter.h; path = Classes/OrFilter.h; sourceTree = "<group>"; };
+		88DB7C0314B2BE68003A96F9 /* OrFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OrFilter.m; path = Classes/OrFilter.m; sourceTree = "<group>"; };
+		88DB7C0514B2C6A6003A96F9 /* AndFilterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AndFilterTest.h; sourceTree = "<group>"; };
+		88DB7C0614B2C6A6003A96F9 /* AndFilterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AndFilterTest.m; sourceTree = "<group>"; };
+		88DB7C2814B3E87E003A96F9 /* ByContextFilterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByContextFilterTest.h; sourceTree = "<group>"; };
+		88DB7C2914B3E87E003A96F9 /* ByContextFilterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ByContextFilterTest.m; sourceTree = "<group>"; };
+		88DB7C2B14B3F140003A96F9 /* ByPriorityFilterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByPriorityFilterTest.h; sourceTree = "<group>"; };
+		88DB7C2C14B3F140003A96F9 /* ByPriorityFilterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ByPriorityFilterTest.m; sourceTree = "<group>"; };
+		88DB7C2E14B3F5C0003A96F9 /* ByProjectFilterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByProjectFilterTest.h; sourceTree = "<group>"; };
+		88DB7C2F14B3F5C0003A96F9 /* ByProjectFilterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ByProjectFilterTest.m; sourceTree = "<group>"; };
+		88DB7C3114B3FDE8003A96F9 /* ByTextFilterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByTextFilterTest.h; sourceTree = "<group>"; };
+		88DB7C3214B3FDE8003A96F9 /* ByTextFilterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ByTextFilterTest.m; sourceTree = "<group>"; };
+		88DB7C3414B4056D003A96F9 /* OrFilterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrFilterTest.h; sourceTree = "<group>"; };
+		88DB7C3514B4056E003A96F9 /* OrFilterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OrFilterTest.m; sourceTree = "<group>"; };
 		88F1AB271412D5F000AB3D18 /* LoginScreenViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoginScreenViewController.h; sourceTree = "<group>"; };
 		88F1AB281412D5F100AB3D18 /* LoginScreenViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoginScreenViewController.m; sourceTree = "<group>"; };
 		88F1AB291412D5F100AB3D18 /* LoginScreenViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LoginScreenViewController.xib; path = Classes/LoginScreenViewController.xib; sourceTree = "<group>"; };
@@ -593,6 +640,21 @@
 				882B3E8713EF46E80085C888 /* TextSplitter.m */,
 				88866D2F13F794320073944B /* Sort.h */,
 				88866D3013F794320073944B /* Sort.m */,
+				88DB7BEE14AFC0E2003A96F9 /* Filter.h */,
+				88DB7BF014AFC3CD003A96F9 /* FilterFactory.h */,
+				88DB7BF114AFC3CE003A96F9 /* FilterFactory.m */,
+				88DB7BF314B2A9F0003A96F9 /* ByContextFilter.h */,
+				88DB7BF414B2A9F0003A96F9 /* ByContextFilter.m */,
+				88DB7BF614B2B073003A96F9 /* ByPriorityFilter.h */,
+				88DB7BF714B2B073003A96F9 /* ByPriorityFilter.m */,
+				88DB7BF914B2B318003A96F9 /* ByProjectFilter.h */,
+				88DB7BFA14B2B319003A96F9 /* ByProjectFilter.m */,
+				88DB7BFC14B2B423003A96F9 /* ByTextFilter.h */,
+				88DB7BFD14B2B423003A96F9 /* ByTextFilter.m */,
+				88DB7BFF14B2B9FA003A96F9 /* AndFilter.h */,
+				88DB7C0014B2B9FB003A96F9 /* AndFilter.m */,
+				88DB7C0214B2BE67003A96F9 /* OrFilter.h */,
+				88DB7C0314B2BE68003A96F9 /* OrFilter.m */,
 			);
 			name = Task;
 			path = ..;
@@ -696,6 +758,18 @@
 				8875F17114AF079F00BFA5C9 /* PriorityTextSplitterTest.m */,
 				8875F17314AF0BAD00BFA5C9 /* PriorityTest.h */,
 				8875F17414AF0BAD00BFA5C9 /* PriorityTest.m */,
+				88DB7C0514B2C6A6003A96F9 /* AndFilterTest.h */,
+				88DB7C0614B2C6A6003A96F9 /* AndFilterTest.m */,
+				88DB7C2814B3E87E003A96F9 /* ByContextFilterTest.h */,
+				88DB7C2914B3E87E003A96F9 /* ByContextFilterTest.m */,
+				88DB7C2B14B3F140003A96F9 /* ByPriorityFilterTest.h */,
+				88DB7C2C14B3F140003A96F9 /* ByPriorityFilterTest.m */,
+				88DB7C2E14B3F5C0003A96F9 /* ByProjectFilterTest.h */,
+				88DB7C2F14B3F5C0003A96F9 /* ByProjectFilterTest.m */,
+				88DB7C3114B3FDE8003A96F9 /* ByTextFilterTest.h */,
+				88DB7C3214B3FDE8003A96F9 /* ByTextFilterTest.m */,
+				88DB7C3414B4056D003A96F9 /* OrFilterTest.h */,
+				88DB7C3514B4056E003A96F9 /* OrFilterTest.m */,
 			);
 			name = Task;
 			sourceTree = "<group>";
@@ -836,6 +910,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88DB7C0A14B2C760003A96F9 /* FilterFactory.m in Sources */,
+				88DB7C0C14B2C760003A96F9 /* ByContextFilter.m in Sources */,
+				88DB7C0E14B2C760003A96F9 /* ByPriorityFilter.m in Sources */,
+				88DB7C1014B2C760003A96F9 /* ByProjectFilter.m in Sources */,
+				88DB7C1214B2C760003A96F9 /* ByTextFilter.m in Sources */,
+				88DB7C1414B2C760003A96F9 /* AndFilter.m in Sources */,
+				88DB7C1614B2C760003A96F9 /* OrFilter.m in Sources */,
+				88DB7C1814B2C760003A96F9 /* AndFilterTest.m in Sources */,
 				8875F16914AF001C00BFA5C9 /* Sort.m in Sources */,
 				888693DE14AEAE93002BB234 /* RelativeDate.m in Sources */,
 				888693DF14AEAE93002BB234 /* Util.m in Sources */,
@@ -856,6 +938,11 @@
 				8875F16F14AF067900BFA5C9 /* ContextParserTest.m in Sources */,
 				8875F17214AF079F00BFA5C9 /* PriorityTextSplitterTest.m in Sources */,
 				8875F17514AF0BAE00BFA5C9 /* PriorityTest.m in Sources */,
+				88DB7C2A14B3E87E003A96F9 /* ByContextFilterTest.m in Sources */,
+				88DB7C2D14B3F140003A96F9 /* ByPriorityFilterTest.m in Sources */,
+				88DB7C3014B3F5C1003A96F9 /* ByProjectFilterTest.m in Sources */,
+				88DB7C3314B3FDE9003A96F9 /* ByTextFilterTest.m in Sources */,
+				88DB7C3614B4056F003A96F9 /* OrFilterTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -863,6 +950,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88DB7C1B14B2C786003A96F9 /* FilterFactory.m in Sources */,
+				88DB7C1D14B2C786003A96F9 /* ByContextFilter.m in Sources */,
+				88DB7C1F14B2C786003A96F9 /* ByPriorityFilter.m in Sources */,
+				88DB7C2114B2C786003A96F9 /* ByProjectFilter.m in Sources */,
+				88DB7C2314B2C786003A96F9 /* ByTextFilter.m in Sources */,
+				88DB7C2514B2C786003A96F9 /* AndFilter.m in Sources */,
+				88DB7C2714B2C786003A96F9 /* OrFilter.m in Sources */,
 				88F043E2148879C1007C32DA /* SSTextView.m in Sources */,
 				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
 				1D3623260D0F684500981E51 /* todo_txt_touch_iosAppDelegate.m in Sources */,

--- a/todo.txt-touch-ios.xcodeproj/project.pbxproj
+++ b/todo.txt-touch-ios.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		0F75B419149912DF00848E27 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		0F75B41A149912DF00848E27 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765A40DF7441C002DB57D /* CoreGraphics.framework */; };
 		0F75B420149912DF00848E27 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0F75B41E149912DF00848E27 /* InfoPlist.strings */; };
-		0F75B422149912DF00848E27 /* Todo_txt_unit_tests.h in Resources */ = {isa = PBXBuildFile; fileRef = 0F75B421149912DF00848E27 /* Todo_txt_unit_tests.h */; };
-		0F75B424149912DF00848E27 /* Todo_txt_unit_tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F75B423149912DF00848E27 /* Todo_txt_unit_tests.m */; };
+		0F75B422149912DF00848E27 /* TaskUtilTest.h in Resources */ = {isa = PBXBuildFile; fileRef = 0F75B421149912DF00848E27 /* TaskUtilTest.h */; };
+		0F75B424149912DF00848E27 /* TaskUtilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F75B423149912DF00848E27 /* TaskUtilTest.m */; };
 		0F75B4311499141800848E27 /* TaskUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F75B4301499141800848E27 /* TaskUtil.m */; };
 		0F75B4321499141800848E27 /* TaskUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F75B4301499141800848E27 /* TaskUtil.m */; };
 		0F75B433149916D900848E27 /* ContextParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 882B3E8413EF46740085C888 /* ContextParser.m */; };
@@ -84,6 +84,15 @@
 		883E430113EB8395002FEBCC /* LocalFileTaskRepository.m in Sources */ = {isa = PBXBuildFile; fileRef = 883E430013EB8395002FEBCC /* LocalFileTaskRepository.m */; };
 		8858D0BA13EA89C50083FA44 /* Priority.m in Sources */ = {isa = PBXBuildFile; fileRef = 8858D0B713EA89C50083FA44 /* Priority.m */; };
 		8858D0BB13EA89C50083FA44 /* Task.m in Sources */ = {isa = PBXBuildFile; fileRef = 8858D0B913EA89C50083FA44 /* Task.m */; };
+		8875F16714AEF5EE00BFA5C9 /* SortTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8875F16614AEF5EE00BFA5C9 /* SortTest.m */; };
+		8875F16914AF001C00BFA5C9 /* Sort.m in Sources */ = {isa = PBXBuildFile; fileRef = 88866D3013F794320073944B /* Sort.m */; };
+		8875F16C14AF024C00BFA5C9 /* ProjectParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8875F16B14AF024B00BFA5C9 /* ProjectParserTest.m */; };
+		8875F16F14AF067900BFA5C9 /* ContextParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8875F16E14AF067800BFA5C9 /* ContextParserTest.m */; };
+		8875F17214AF079F00BFA5C9 /* PriorityTextSplitterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8875F17114AF079F00BFA5C9 /* PriorityTextSplitterTest.m */; };
+		8875F17514AF0BAE00BFA5C9 /* PriorityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8875F17414AF0BAD00BFA5C9 /* PriorityTest.m */; };
+		8876EF5B14AD79EE00F28C3C /* Strings.m in Sources */ = {isa = PBXBuildFile; fileRef = 8876EF5A14AD79EE00F28C3C /* Strings.m */; };
+		8876EF6114AD7E8100F28C3C /* Strings.m in Sources */ = {isa = PBXBuildFile; fileRef = 8876EF5A14AD79EE00F28C3C /* Strings.m */; };
+		8876EF6214AD7E8D00F28C3C /* StringsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8876EF5F14AD7D3E00F28C3C /* StringsTest.m */; };
 		8878944014954AE4000AC39C /* DropboxTodoDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 8878943F14954AE4000AC39C /* DropboxTodoDownloader.m */; };
 		887894441495AEC7000AC39C /* DropboxTodoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 887894431495AEC7000AC39C /* DropboxTodoUploader.m */; };
 		888065951401898E0036DE2A /* RemoteClientManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 888065941401898E0036DE2A /* RemoteClientManager.m */; };
@@ -95,7 +104,15 @@
 		888286AB146E5165007DBB16 /* PGTableViewWithEmptyView.m in Sources */ = {isa = PBXBuildFile; fileRef = 888286AA146E5165007DBB16 /* PGTableViewWithEmptyView.m */; };
 		888286AD146E52C5007DBB16 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 888286AC146E52C5007DBB16 /* QuartzCore.framework */; };
 		88866D3113F794320073944B /* Sort.m in Sources */ = {isa = PBXBuildFile; fileRef = 88866D3013F794320073944B /* Sort.m */; };
+		888693DB14AEA4EE002BB234 /* TaskTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 888693DA14AEA4EE002BB234 /* TaskTest.m */; };
+		888693DD14AEAE71002BB234 /* Task.m in Sources */ = {isa = PBXBuildFile; fileRef = 8858D0B913EA89C50083FA44 /* Task.m */; };
+		888693DE14AEAE93002BB234 /* RelativeDate.m in Sources */ = {isa = PBXBuildFile; fileRef = 59216D3D13EA318100FF07EE /* RelativeDate.m */; };
+		888693DF14AEAE93002BB234 /* Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 59216C7413E8C89200FF07EE /* Util.m */; };
 		8887496D13F3715400871E49 /* ActionSheetPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 8887496C13F3715400871E49 /* ActionSheetPicker.m */; };
+		88A5B6C014ADA8B700EA6F70 /* Priority.m in Sources */ = {isa = PBXBuildFile; fileRef = 8858D0B713EA89C50083FA44 /* Priority.m */; };
+		88A5B6C114ADA8C200EA6F70 /* TextSplitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 882B3E8713EF46E80085C888 /* TextSplitter.m */; };
+		88A5B6C214ADA8CA00EA6F70 /* TextSplitterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A5B6BE14ADA63100EA6F70 /* TextSplitterTest.m */; };
+		88A5B6C314ADA91000EA6F70 /* PriorityTextSplitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 882B3E8A13EF47610085C888 /* PriorityTextSplitter.m */; };
 		88A91724146614920075B886 /* DropboxSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88A91723146614920075B886 /* DropboxSDK.framework */; };
 		88AAFC631419CB960062BBF6 /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 88AAFC621419CB960062BBF6 /* Icon@2x.png */; };
 		88F043E2148879C1007C32DA /* SSTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 88334817146F5D4F009CBDE9 /* SSTextView.m */; };
@@ -123,8 +140,8 @@
 		0F75B416149912DF00848E27 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		0F75B41D149912DF00848E27 /* Todo-txt-unit-tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Todo-txt-unit-tests-Info.plist"; sourceTree = "<group>"; };
 		0F75B41F149912DF00848E27 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		0F75B421149912DF00848E27 /* Todo_txt_unit_tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Todo_txt_unit_tests.h; sourceTree = "<group>"; };
-		0F75B423149912DF00848E27 /* Todo_txt_unit_tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Todo_txt_unit_tests.m; sourceTree = "<group>"; };
+		0F75B421149912DF00848E27 /* TaskUtilTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TaskUtilTest.h; sourceTree = "<group>"; };
+		0F75B423149912DF00848E27 /* TaskUtilTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TaskUtilTest.m; sourceTree = "<group>"; };
 		0F75B425149912DF00848E27 /* Todo-txt-unit-tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Todo-txt-unit-tests-Prefix.pch"; sourceTree = "<group>"; };
 		0F75B42F1499141800848E27 /* TaskUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaskUtil.h; sourceTree = "<group>"; };
 		0F75B4301499141800848E27 /* TaskUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TaskUtil.m; sourceTree = "<group>"; };
@@ -235,6 +252,20 @@
 		8858D0B713EA89C50083FA44 /* Priority.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Priority.m; path = Classes/Priority.m; sourceTree = "<group>"; };
 		8858D0B813EA89C50083FA44 /* Task.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Task.h; path = Classes/Task.h; sourceTree = "<group>"; };
 		8858D0B913EA89C50083FA44 /* Task.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Task.m; path = Classes/Task.m; sourceTree = "<group>"; };
+		8875F16514AEF5EE00BFA5C9 /* SortTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SortTest.h; sourceTree = "<group>"; };
+		8875F16614AEF5EE00BFA5C9 /* SortTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SortTest.m; sourceTree = "<group>"; };
+		8875F16A14AF024B00BFA5C9 /* ProjectParserTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProjectParserTest.h; sourceTree = "<group>"; };
+		8875F16B14AF024B00BFA5C9 /* ProjectParserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProjectParserTest.m; sourceTree = "<group>"; };
+		8875F16D14AF067800BFA5C9 /* ContextParserTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextParserTest.h; sourceTree = "<group>"; };
+		8875F16E14AF067800BFA5C9 /* ContextParserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContextParserTest.m; sourceTree = "<group>"; };
+		8875F17014AF079F00BFA5C9 /* PriorityTextSplitterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PriorityTextSplitterTest.h; sourceTree = "<group>"; };
+		8875F17114AF079F00BFA5C9 /* PriorityTextSplitterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PriorityTextSplitterTest.m; sourceTree = "<group>"; };
+		8875F17314AF0BAD00BFA5C9 /* PriorityTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PriorityTest.h; sourceTree = "<group>"; };
+		8875F17414AF0BAD00BFA5C9 /* PriorityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PriorityTest.m; sourceTree = "<group>"; };
+		8876EF5914AD79EE00F28C3C /* Strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Strings.h; sourceTree = "<group>"; };
+		8876EF5A14AD79EE00F28C3C /* Strings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Strings.m; sourceTree = "<group>"; };
+		8876EF5E14AD7D3E00F28C3C /* StringsTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringsTest.h; sourceTree = "<group>"; };
+		8876EF5F14AD7D3E00F28C3C /* StringsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StringsTest.m; sourceTree = "<group>"; };
 		8878943E14954AE4000AC39C /* DropboxTodoDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DropboxTodoDownloader.h; sourceTree = "<group>"; };
 		8878943F14954AE4000AC39C /* DropboxTodoDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DropboxTodoDownloader.m; sourceTree = "<group>"; };
 		887894421495AEC7000AC39C /* DropboxTodoUploader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DropboxTodoUploader.h; sourceTree = "<group>"; };
@@ -254,8 +285,12 @@
 		888286AC146E52C5007DBB16 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		88866D2F13F794320073944B /* Sort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sort.h; path = Classes/Sort.h; sourceTree = "<group>"; };
 		88866D3013F794320073944B /* Sort.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Sort.m; path = Classes/Sort.m; sourceTree = "<group>"; };
+		888693D914AEA4EE002BB234 /* TaskTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaskTest.h; sourceTree = "<group>"; };
+		888693DA14AEA4EE002BB234 /* TaskTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TaskTest.m; sourceTree = "<group>"; };
 		8887496B13F3715400871E49 /* ActionSheetPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActionSheetPicker.h; sourceTree = "<group>"; };
 		8887496C13F3715400871E49 /* ActionSheetPicker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ActionSheetPicker.m; sourceTree = "<group>"; };
+		88A5B6BD14ADA63100EA6F70 /* TextSplitterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextSplitterTest.h; sourceTree = "<group>"; };
+		88A5B6BE14ADA63100EA6F70 /* TextSplitterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TextSplitterTest.m; sourceTree = "<group>"; };
 		88A91723146614920075B886 /* DropboxSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = DropboxSDK.framework; sourceTree = "<group>"; };
 		88A91726146643B70075B886 /* DropboxApiKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DropboxApiKey.h; path = ../DropboxApiKey.h; sourceTree = "<group>"; };
 		88AAFC621419CB960062BBF6 /* Icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon@2x.png"; sourceTree = "<group>"; };
@@ -360,8 +395,8 @@
 		0F75B41B149912DF00848E27 /* Todo-txt-unit-tests */ = {
 			isa = PBXGroup;
 			children = (
-				0F75B421149912DF00848E27 /* Todo_txt_unit_tests.h */,
-				0F75B423149912DF00848E27 /* Todo_txt_unit_tests.m */,
+				88A5B6BB14ADA5F700EA6F70 /* Task */,
+				8876EF5D14AD7CFE00F28C3C /* Util */,
 				0F75B41C149912DF00848E27 /* Supporting Files */,
 			);
 			path = "Todo-txt-unit-tests";
@@ -593,6 +628,8 @@
 				88334817146F5D4F009CBDE9 /* SSTextView.m */,
 				0F75B42F1499141800848E27 /* TaskUtil.h */,
 				0F75B4301499141800848E27 /* TaskUtil.m */,
+				8876EF5914AD79EE00F28C3C /* Strings.h */,
+				8876EF5A14AD79EE00F28C3C /* Strings.m */,
 			);
 			name = Util;
 			sourceTree = "<group>";
@@ -622,6 +659,17 @@
 			name = Remote;
 			sourceTree = "<group>";
 		};
+		8876EF5D14AD7CFE00F28C3C /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				8876EF5E14AD7D3E00F28C3C /* StringsTest.h */,
+				8876EF5F14AD7D3E00F28C3C /* StringsTest.m */,
+				0F75B421149912DF00848E27 /* TaskUtilTest.h */,
+				0F75B423149912DF00848E27 /* TaskUtilTest.m */,
+			);
+			name = Util;
+			sourceTree = "<group>";
+		};
 		888286A8146E5165007DBB16 /* PGTableWithEmptyView */ = {
 			isa = PBXGroup;
 			children = (
@@ -629,6 +677,27 @@
 				888286AA146E5165007DBB16 /* PGTableViewWithEmptyView.m */,
 			);
 			path = PGTableWithEmptyView;
+			sourceTree = "<group>";
+		};
+		88A5B6BB14ADA5F700EA6F70 /* Task */ = {
+			isa = PBXGroup;
+			children = (
+				88A5B6BD14ADA63100EA6F70 /* TextSplitterTest.h */,
+				88A5B6BE14ADA63100EA6F70 /* TextSplitterTest.m */,
+				888693D914AEA4EE002BB234 /* TaskTest.h */,
+				888693DA14AEA4EE002BB234 /* TaskTest.m */,
+				8875F16514AEF5EE00BFA5C9 /* SortTest.h */,
+				8875F16614AEF5EE00BFA5C9 /* SortTest.m */,
+				8875F16A14AF024B00BFA5C9 /* ProjectParserTest.h */,
+				8875F16B14AF024B00BFA5C9 /* ProjectParserTest.m */,
+				8875F16D14AF067800BFA5C9 /* ContextParserTest.h */,
+				8875F16E14AF067800BFA5C9 /* ContextParserTest.m */,
+				8875F17014AF079F00BFA5C9 /* PriorityTextSplitterTest.h */,
+				8875F17114AF079F00BFA5C9 /* PriorityTextSplitterTest.m */,
+				8875F17314AF0BAD00BFA5C9 /* PriorityTest.h */,
+				8875F17414AF0BAD00BFA5C9 /* PriorityTest.m */,
+			);
+			name = Task;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -704,7 +773,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0F75B420149912DF00848E27 /* InfoPlist.strings in Resources */,
-				0F75B422149912DF00848E27 /* Todo_txt_unit_tests.h in Resources */,
+				0F75B422149912DF00848E27 /* TaskUtilTest.h in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -767,10 +836,26 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0F75B424149912DF00848E27 /* Todo_txt_unit_tests.m in Sources */,
+				8875F16914AF001C00BFA5C9 /* Sort.m in Sources */,
+				888693DE14AEAE93002BB234 /* RelativeDate.m in Sources */,
+				888693DF14AEAE93002BB234 /* Util.m in Sources */,
+				888693DD14AEAE71002BB234 /* Task.m in Sources */,
+				88A5B6C314ADA91000EA6F70 /* PriorityTextSplitter.m in Sources */,
+				88A5B6C214ADA8CA00EA6F70 /* TextSplitterTest.m in Sources */,
+				88A5B6C114ADA8C200EA6F70 /* TextSplitter.m in Sources */,
+				88A5B6C014ADA8B700EA6F70 /* Priority.m in Sources */,
+				8876EF6214AD7E8D00F28C3C /* StringsTest.m in Sources */,
+				8876EF6114AD7E8100F28C3C /* Strings.m in Sources */,
+				0F75B424149912DF00848E27 /* TaskUtilTest.m in Sources */,
 				0F75B4321499141800848E27 /* TaskUtil.m in Sources */,
 				0F75B433149916D900848E27 /* ContextParser.m in Sources */,
 				0F75B434149923E700848E27 /* ProjectParser.m in Sources */,
+				888693DB14AEA4EE002BB234 /* TaskTest.m in Sources */,
+				8875F16714AEF5EE00BFA5C9 /* SortTest.m in Sources */,
+				8875F16C14AF024C00BFA5C9 /* ProjectParserTest.m in Sources */,
+				8875F16F14AF067900BFA5C9 /* ContextParserTest.m in Sources */,
+				8875F17214AF079F00BFA5C9 /* PriorityTextSplitterTest.m in Sources */,
+				8875F17514AF0BAE00BFA5C9 /* PriorityTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -836,6 +921,7 @@
 				8878944014954AE4000AC39C /* DropboxTodoDownloader.m in Sources */,
 				887894441495AEC7000AC39C /* DropboxTodoUploader.m in Sources */,
 				0F75B4311499141800848E27 /* TaskUtil.m in Sources */,
+				8876EF5B14AD79EE00F28C3C /* Strings.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Added backend logic for filtering (with unit tests!). It works with our existing search UI and has support for other filters whenever they get added (see #18).

Since we now have a testing framework, I figured it would be easy to implement and test this logic even though we don't have UI for it yet. It was just a one-to-one port of the Android code. I'm still leaving the UI up to @bigbash and @jperkel :) .
