### PR TITLE
Added gloss-free icons to iOS 4 and iTunes Connect

### DIFF
--- a/todo_txt_touch_ios-Info.plist
+++ b/todo_txt_touch_ios-Info.plist
@@ -76,5 +76,7 @@
 	<array/>
 	<key>UTImportedTypeDeclarations</key>
 	<array/>
+	<key>UIPrerenderedIcon</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Hey Gina,

As you mentioned on your blog post, the App Store displays gloss despite your plist saying otherwise. I decided to fix it for you. Here's what was causing it:

Your plist had UIPrerenderedIcon defined inside a key that was introduced in iOS 5. Prior versions of iOS, as well as iTunes Connect, look for the old key, which is UIPrerenderedIcon at the root of the plist. My commit literally just adds that key to the plist. I'm sorry I didn't have a more awesome solution.

Best of luck with the app. :)
