### PR TITLE
Fix swipe to Complete an already completed task by toggling swipe to Inc...

### DIFF
--- a/Classes/todo_txt_touch_iosViewController.m
+++ b/Classes/todo_txt_touch_iosViewController.m
@@ -291,7 +291,11 @@ shouldReloadTableForSearchString:(NSString *)searchString
 {
     id<TaskBag> taskBag = [todo_txt_touch_iosAppDelegate sharedTaskBag];
     Task *task = [self taskForTable:tableView atIndex:indexPath.row];
-    [task markComplete:[NSDate date]];
+     if (task.completed) {
+        [task markIncomplete];
+    } else {
+	[task markComplete:[NSDate date]];
+    }
     [taskBag update:task];
     [self reloadData:nil];
     [todo_txt_touch_iosAppDelegate pushToRemote];
@@ -299,7 +303,12 @@ shouldReloadTableForSearchString:(NSString *)searchString
 
 -(NSString *)tableView:(UITableView *)tableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return @"Complete";
+        Task *task = [self taskForTable:tableView atIndex:indexPath.row];
+    if (task.completed) {
+        return @"Incomplete";
+    } else {
+    	return @"Complete";
+    }
 }
 
 


### PR DESCRIPTION
...omplete.
Hi Gina,
Apologies in advance for my newbyness to github and whatever normal procedures are here.
I noticed when you swipe a task it displays a "Complete" button even if a completed task is swiped. This change will toggle the button to Incomplete and change the task back to normal (incomplete).
I found this after reading a different "bug" report on the yahoo group. You may see a post from me there before I decided to take the time to post it here.
Thanks for publishing your source.
Joe
