### PR TITLE
Handle missing/deleted files better

### DIFF
--- a/Classes/DropboxFileDownloader.m
+++ b/Classes/DropboxFileDownloader.m
@@ -121,6 +121,8 @@
 	if ([metadata.rev isEqualToString:file.originalRev]) {
 		// don't bother downloading if the rev is the same
 		file.status = dbNotChanged;
+    } else if (metadata.isDeleted) {
+        file.status = dbNotFound;
 	} else {
 		file.status = dbFound;
 	}

--- a/Classes/DropboxFileUploader.m
+++ b/Classes/DropboxFileUploader.m
@@ -119,20 +119,26 @@
 - (void)restClient:(DBRestClient*)client loadedMetadata:(DBMetadata*)metadata {
 	DropboxFile *file = [files objectAtIndex:curFile];
 	
-	// save off the returned metadata
-	file.loadedMetadata = metadata;	
+    if (metadata.isDeleted) {
+        // if the file does not exist, we can upload it with a nil parentrev
+        file.loadedMetadata = nil;
+        file.status = dbNotFound;
+    } else {
+        // save off the returned metadata
+        file.loadedMetadata = metadata;	
 
-	if (!overwrite && ![metadata.rev isEqualToString:file.originalRev]) {
-		// Conflict! Stop everything and return to caller
-		file.status = dbConflict;
-		status = dbConflict;
-		[target performSelector:onComplete];
-		
-		return;
-	}
-	
-	file.status = dbFound;
-
+        if (!overwrite && ![metadata.rev isEqualToString:file.originalRev]) {
+            // Conflict! Stop everything and return to caller
+            file.status = dbConflict;
+            status = dbConflict;
+            [target performSelector:onComplete];
+            
+            return;
+        }
+        
+        file.status = dbFound;
+    }
+    
 	// get the next metadata
 	[self loadNextMetadata];
 }

--- a/Classes/DropboxRemoteClient.m
+++ b/Classes/DropboxRemoteClient.m
@@ -208,8 +208,8 @@
 	
 	if (todoUploader.status == dbError) {
 		// call remote client delegate function
-		if (self.delegate && [self.delegate respondsToSelector:@selector(remoteClient:loadFileFailedWithError:)]) {
-			[self.delegate remoteClient:self loadFileFailedWithError:todoDownloader.error];
+		if (self.delegate && [self.delegate respondsToSelector:@selector(remoteClient:uploadFileFailedWithError:)]) {
+			[self.delegate remoteClient:self uploadFileFailedWithError:todoDownloader.error];
 		}
 	} else if (todoUploader.status == dbConflict) {
 		NSString *conflictFile = nil;

--- a/Classes/LocalFileTaskRepository.m
+++ b/Classes/LocalFileTaskRepository.m
@@ -89,17 +89,19 @@
 }
 
 - (BOOL) todoFileModifiedSince:(NSDate*)date {
-	if (date) {
-		return [date compare:[self todoFileLastModified]] == NSOrderedAscending;
-	}
-	return YES;
+    NSDate *lastModified = [self todoFileLastModified];
+	if (!date) {
+        date = [NSDate distantPast];
+    }
+    return [date compare:lastModified] == NSOrderedAscending;
 }
 
 - (BOOL) doneFileModifiedSince:(NSDate*)date {
-	if (date) {
-		return [date compare:[self doneFileLastModified]] == NSOrderedAscending;
-	}
-	return YES;
+    NSDate *lastModified = [self doneFileLastModified];
+	if (!date) {
+        date = [NSDate distantPast];
+    }
+    return [date compare:lastModified] == NSOrderedAscending;
 }
 
 - (void) create {


### PR DESCRIPTION
Hopefully this should fix the bug mentioned [here](https://github.com/ginatrapani/todo.txt-touch-ios/pull/122#issuecomment-4227905) in #122.

My internets have been acting wonky today, so it has been difficult to test.
1. We now handle the case where Dropbox tells us that a file exists but has been deleted. We treat it as if the file never existed.
2. We now properly consider a non-existent local copy of done.txt as "not modified" so we won't try to upload it.
3. Fixed a minor issue where we were displaying "Error downloading" after failing to upload.
