### PR TITLE
Dismiss login view from its parent instead of itself so that all childre...

### DIFF
--- a/Classes/todo_txt_touch_iosAppDelegate.m
+++ b/Classes/todo_txt_touch_iosAppDelegate.m
@@ -126,7 +126,12 @@
 }
 
 - (void) presentMainViewController {
-    [loginController dismissModalViewControllerAnimated:YES];
+	if ([[loginController parentViewController] respondsToSelector:@selector(dismissModalViewControllerAnimated:)]){
+        [[loginController parentViewController] dismissModalViewControllerAnimated:YES];
+    } else {
+        [[loginController presentingViewController] dismissViewControllerAnimated:YES completion:nil];
+    }
+    
     [loginController release];
     loginController = nil;
 }
@@ -451,9 +456,11 @@ BOOL wasConnected = YES;
 
 - (void)remoteClient:(id<RemoteClient>)client loginControllerDidLogin:(BOOL)success {
 	if (success) {
-		// Don't sync because we already did that when the app was reactivated by Dropbox
-        // We may need to do something else for other services.
-        //[self syncClient];
+		// If we login using the Dropbox app we will sync after re-activation.
+		// But, if we login using the webview, we never leave the app,
+		// so we have to sync now. Unfortunately, this causes a double
+		// sync when the Dropbox app is used, but I don't see an easy way around that.
+        [self syncClient];
 		[self presentMainViewController];
 	}
 }


### PR DESCRIPTION
...n views are dismissed as well.

Also, we need to sync after logging in because it will not happen if the login is handled through the Dropbox framework (when the Dropbox app is not installed). This will cause a double sync when the Dropbox app is used to login because we will sync when our app is reactivated. I don't see a way around that, though. And it shouldn't be a big deal because we only download when things have changed.
