### PR TITLE
re issue #152 - animate login view presentation, ensure visibility

### DIFF
--- a/Classes/todo_txt_touch_iosAppDelegate.m
+++ b/Classes/todo_txt_touch_iosAppDelegate.m
@@ -136,9 +136,18 @@
     loginController = nil;
 }
 
+// http://stackoverflow.com/questions/9679163/why-does-clearing-nsuserdefaults-cause-exc-crash-later-when-creating-a-uiwebview
+//
 - (void) clearUserDefaults {
 	NSString *appDomain = [[NSBundle mainBundle] bundleIdentifier];
-	[[NSUserDefaults standardUserDefaults] removePersistentDomainForName:appDomain];
+	
+	id workaround51Crash = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitLocalStorageDatabasePathPreferenceKey"];
+	
+	NSDictionary *emptySettings = (workaround51Crash != nil)
+	? [NSDictionary dictionaryWithObject:workaround51Crash forKey:@"WebKitLocalStorageDatabasePathPreferenceKey"]
+	: [NSDictionary dictionary];
+	
+	[[NSUserDefaults standardUserDefaults] setPersistentDomain:emptySettings forName:appDomain];
 }
 
 

--- a/Classes/todo_txt_touch_iosAppDelegate.m
+++ b/Classes/todo_txt_touch_iosAppDelegate.m
@@ -122,7 +122,7 @@
     {
         loginController = [[LoginScreenViewController alloc] init];
     }
-    [self.navigationController presentModalViewController:loginController animated:NO];
+    [self.navigationController presentModalViewController:loginController animated:YES];
 }
 
 - (void) presentMainViewController {


### PR DESCRIPTION
I was able to replicate the bug in the iPad 5.1 Simulator, but I don't have access to an physical 5.x device.

This clears up the issue under iOS 5, and logins still work as expected under iOS 6.
