### PR TITLE
Fixed compiler warning

### DIFF
--- a/Classes/Priority.m
+++ b/Classes/Priority.m
@@ -50,7 +50,7 @@ static NSArray* priorityArray = nil;
 
 @synthesize name, code, listFormat, detailFormat, fileFormat;
 
-- (id)initWithName:(PriorityName)theName :(NSString*)theCode:(NSString*)theListFormat:(NSString*)theDetailFormat:(NSString*)theFileFormat {
+- (id)initWithName:(PriorityName)theName withCode:(NSString*)theCode withListFormat:(NSString*)theListFormat withDetailFormat:(NSString*)theDetailFormat withFileFormat:(NSString*)theFileFormat {
 	self = [super init];
 	if (self) {
 		name = theName;
@@ -75,41 +75,41 @@ static NSArray* priorityArray = nil;
 	return [code hash];
 }
 
-+(Priority *)priorityWithName:(PriorityName)theName :(NSString*)theCode:(NSString*)theListFormat:(NSString*)theDetailFormat:(NSString*)theFileFormat {
-	return [[[Priority alloc] initWithName:theName :theCode :theListFormat :theDetailFormat :theFileFormat] autorelease];
++(Priority *)priorityWithName:(PriorityName)theName withCode:(NSString*)theCode withListFormat:(NSString*)theListFormat withDetailFormat:(NSString*)theDetailFormat withFileFormat:(NSString*)theFileFormat {
+	return [[[Priority alloc] initWithName:theName withCode:theCode withListFormat:theListFormat withDetailFormat:theDetailFormat withFileFormat:theFileFormat] autorelease];
 }
 
 + (void)initialize {
 	@synchronized(self) {
 		if (!priorityArray) {
 			priorityArray = [[NSArray arrayWithObjects:
-							  [Priority priorityWithName:PriorityNone :@"-" :@" " :@"" :@""],
-							  [Priority priorityWithName:PriorityA :@"A" :@"A" :@"A" :@"(A)"],
-							  [Priority priorityWithName:PriorityB :@"B" :@"B" :@"B" :@"(B)"],
-							  [Priority priorityWithName:PriorityC :@"C" :@"C" :@"C" :@"(C)"],
-							  [Priority priorityWithName:PriorityD :@"D" :@"D" :@"D" :@"(D)"],
-							  [Priority priorityWithName:PriorityE :@"E" :@"E" :@"E" :@"(E)"],
-							  [Priority priorityWithName:PriorityF :@"F" :@"F" :@"F" :@"(F)"],
-							  [Priority priorityWithName:PriorityG :@"G" :@"G" :@"G" :@"(G)"],
-							  [Priority priorityWithName:PriorityH :@"H" :@"H" :@"H" :@"(H)"],
-							  [Priority priorityWithName:PriorityI :@"I" :@"I" :@"I" :@"(I)"],
-							  [Priority priorityWithName:PriorityJ :@"J" :@"J" :@"J" :@"(J)"],
-							  [Priority priorityWithName:PriorityK :@"K" :@"K" :@"K" :@"(K)"],
-							  [Priority priorityWithName:PriorityL :@"L" :@"L" :@"L" :@"(L)"],
-							  [Priority priorityWithName:PriorityM :@"M" :@"M" :@"M" :@"(M)"],
-							  [Priority priorityWithName:PriorityN :@"N" :@"N" :@"N" :@"(N)"],
-							  [Priority priorityWithName:PriorityO :@"O" :@"O" :@"O" :@"(O)"],
-							  [Priority priorityWithName:PriorityP :@"P" :@"P" :@"P" :@"(P)"],
-							  [Priority priorityWithName:PriorityQ :@"Q" :@"Q" :@"Q" :@"(Q)"],
-							  [Priority priorityWithName:PriorityR :@"R" :@"R" :@"R" :@"(R)"],
-							  [Priority priorityWithName:PriorityS :@"S" :@"S" :@"S" :@"(S)"],
-							  [Priority priorityWithName:PriorityT :@"T" :@"T" :@"T" :@"(T)"],
-							  [Priority priorityWithName:PriorityU :@"U" :@"U" :@"U" :@"(U)"],
-							  [Priority priorityWithName:PriorityV :@"V" :@"V" :@"V" :@"(V)"],
-							  [Priority priorityWithName:PriorityW :@"W" :@"W" :@"W" :@"(W)"],
-							  [Priority priorityWithName:PriorityX :@"X" :@"X" :@"X" :@"(X)"],
-							  [Priority priorityWithName:PriorityY :@"Y" :@"Y" :@"Y" :@"(Y)"],
-							  [Priority priorityWithName:PriorityZ :@"Z" :@"Z" :@"Z" :@"(Z)"],
+							  [Priority priorityWithName:PriorityNone withCode:@"-" withListFormat:@" " withDetailFormat:@"" withFileFormat:@""],
+							  [Priority priorityWithName:PriorityA withCode:@"A" withListFormat:@"A" withDetailFormat:@"A" withFileFormat:@"(A)"],
+							  [Priority priorityWithName:PriorityB withCode:@"B" withListFormat:@"B" withDetailFormat:@"B" withFileFormat:@"(B)"],
+							  [Priority priorityWithName:PriorityC withCode:@"C" withListFormat:@"C" withDetailFormat:@"C" withFileFormat:@"(C)"],
+							  [Priority priorityWithName:PriorityD withCode:@"D" withListFormat:@"D" withDetailFormat:@"D" withFileFormat:@"(D)"],
+							  [Priority priorityWithName:PriorityE withCode:@"E" withListFormat:@"E" withDetailFormat:@"E" withFileFormat:@"(E)"],
+							  [Priority priorityWithName:PriorityF withCode:@"F" withListFormat:@"F" withDetailFormat:@"F" withFileFormat:@"(F)"],
+							  [Priority priorityWithName:PriorityG withCode:@"G" withListFormat:@"G" withDetailFormat:@"G" withFileFormat:@"(G)"],
+							  [Priority priorityWithName:PriorityH withCode:@"H" withListFormat:@"H" withDetailFormat:@"H" withFileFormat:@"(H)"],
+							  [Priority priorityWithName:PriorityI withCode:@"I" withListFormat:@"I" withDetailFormat:@"I" withFileFormat:@"(I)"],
+							  [Priority priorityWithName:PriorityJ withCode:@"J" withListFormat:@"J" withDetailFormat:@"J" withFileFormat:@"(J)"],
+							  [Priority priorityWithName:PriorityK withCode:@"K" withListFormat:@"K" withDetailFormat:@"K" withFileFormat:@"(K)"],
+							  [Priority priorityWithName:PriorityL withCode:@"L" withListFormat:@"L" withDetailFormat:@"L" withFileFormat:@"(L)"],
+							  [Priority priorityWithName:PriorityM withCode:@"M" withListFormat:@"M" withDetailFormat:@"M" withFileFormat:@"(M)"],
+							  [Priority priorityWithName:PriorityN withCode:@"N" withListFormat:@"N" withDetailFormat:@"N" withFileFormat:@"(N)"],
+							  [Priority priorityWithName:PriorityO withCode:@"O" withListFormat:@"O" withDetailFormat:@"O" withFileFormat:@"(O)"],
+							  [Priority priorityWithName:PriorityP withCode:@"P" withListFormat:@"P" withDetailFormat:@"P" withFileFormat:@"(P)"],
+							  [Priority priorityWithName:PriorityQ withCode:@"Q" withListFormat:@"Q" withDetailFormat:@"Q" withFileFormat:@"(Q)"],
+							  [Priority priorityWithName:PriorityR withCode:@"R" withListFormat:@"R" withDetailFormat:@"R" withFileFormat:@"(R)"],
+							  [Priority priorityWithName:PriorityS withCode:@"S" withListFormat:@"S" withDetailFormat:@"S" withFileFormat:@"(S)"],
+							  [Priority priorityWithName:PriorityT withCode:@"T" withListFormat:@"T" withDetailFormat:@"T" withFileFormat:@"(T)"],
+							  [Priority priorityWithName:PriorityU withCode:@"U" withListFormat:@"U" withDetailFormat:@"U" withFileFormat:@"(U)"],
+							  [Priority priorityWithName:PriorityV withCode:@"V" withListFormat:@"V" withDetailFormat:@"V" withFileFormat:@"(V)"],
+							  [Priority priorityWithName:PriorityW withCode:@"W" withListFormat:@"W" withDetailFormat:@"W" withFileFormat:@"(W)"],
+							  [Priority priorityWithName:PriorityX withCode:@"X" withListFormat:@"X" withDetailFormat:@"X" withFileFormat:@"(X)"],
+							  [Priority priorityWithName:PriorityY withCode:@"Y" withListFormat:@"Y" withDetailFormat:@"Y" withFileFormat:@"(Y)"],
+							  [Priority priorityWithName:PriorityZ withCode:@"Z" withListFormat:@"Z" withDetailFormat:@"Z" withFileFormat:@"(Z)"],
 							  nil
 							 ] retain];
 		}

--- a/Classes/TaskEditViewController.m
+++ b/Classes/TaskEditViewController.m
@@ -263,7 +263,7 @@
 	[textView becomeFirstResponder];
 }
 
-- (void) priorityWasSelected:(NSNumber *)selectedIndex:(id)element {
+- (void) priorityWasSelected:(NSNumber *)selectedIndex element:(id)element {
 	self.actionSheetPicker = nil;
 	if (selectedIndex.intValue >= 0) {
 		Priority *selectedPriority = [Priority byName:(PriorityName)selectedIndex.intValue];
@@ -282,7 +282,7 @@
 	[textView becomeFirstResponder];
 }
 
-- (void) projectWasSelected:(NSNumber *)selectedIndex:(id)element {
+- (void) projectWasSelected:(NSNumber *)selectedIndex element:(id)element {
 	self.actionSheetPicker = nil;
 	if (selectedIndex.intValue >= 0) {
 		id<TaskBag> taskBag = [todo_txt_touch_iosAppDelegate sharedTaskBag];
@@ -299,7 +299,7 @@
 	[textView becomeFirstResponder];
 }
 
-- (void) contextWasSelected:(NSNumber *)selectedIndex:(id)element {
+- (void) contextWasSelected:(NSNumber *)selectedIndex element:(id)element {
 	self.actionSheetPicker = nil;
 	if (selectedIndex.intValue >= 0) {
 		id<TaskBag> taskBag = [todo_txt_touch_iosAppDelegate sharedTaskBag];
@@ -337,7 +337,7 @@
 													  data:[taskBag contexts]
 											 selectedIndex:0
 													target:self 
-													action:@selector(contextWasSelected::) 
+													action:@selector(contextWasSelected:element:)
 													 title:@"Select Context"
 													  rect:CGRectZero
 											 barButtonItem:button];			
@@ -347,7 +347,7 @@
                                                   data:[Priority allCodes]
                                          selectedIndex:curPriority
                                                 target:self 
-                                                action:@selector(priorityWasSelected::) 
+                                                action:@selector(priorityWasSelected:element:)
 												 title:@"Select Priority"
 												  rect:CGRectZero
 										 barButtonItem:button];
@@ -357,7 +357,7 @@
                                               data:[taskBag projects]
                                      selectedIndex:0
                                             target:self 
-                                            action:@selector(projectWasSelected::) 
+                                            action:@selector(projectWasSelected:element:)
 											 title:@"Select Project"
 											  rect:CGRectZero
 									 barButtonItem:button];			

--- a/Classes/TaskViewController.m
+++ b/Classes/TaskViewController.m
@@ -442,7 +442,7 @@ char *completed_buttons[] = { "Undo Complete", "Delete" };
 	[self performSelectorOnMainThread:@selector(reloadViewData) withObject:nil waitUntilDone:NO];
 }
 
-- (void) priorityWasSelected:(NSNumber *)selectedIndex:(id)element {
+- (void) priorityWasSelected:(NSNumber *)selectedIndex element:(id)element {
 	//TODO: progress dialog
 	if (selectedIndex.intValue >= 0) {
 		Priority *selectedPriority = [Priority byName:(PriorityName)selectedIndex.intValue];
@@ -472,7 +472,7 @@ char *completed_buttons[] = { "Undo Complete", "Delete" };
 						data:[Priority allCodes]
 						selectedIndex:curPriority 
 						target:self 
-						action:@selector(priorityWasSelected::) 
+						action:@selector(priorityWasSelected:element:)
 						title:@"Select Priority"
 						 rect:cell.frame
 				barButtonItem:nil];

--- a/Classes/todo_txt_touch_iosViewController.m
+++ b/Classes/todo_txt_touch_iosViewController.m
@@ -408,7 +408,7 @@ shouldReloadTableForSearchString:(NSString *)searchString
     }
 }
 
-- (void) sortOrderWasSelected:(NSNumber *)selectedIndex:(id)element {
+- (void) sortOrderWasSelected:(NSNumber *)selectedIndex element:(id)element {
 	self.actionSheetPicker = nil;
 	if (selectedIndex.intValue >= 0) {
 		sort = [Sort byName:selectedIndex.intValue];
@@ -433,7 +433,7 @@ shouldReloadTableForSearchString:(NSString *)searchString
 //																			   data:[Sort descriptions]
 //																	  selectedIndex:[sort name]
 //																			 target:self 
-//																			 action:@selector(sortOrderWasSelected::) 
+//																			 action:@selector(sortOrderWasSelected:element:)
 //																			  title:@"Select Sort Order"
 //																			   rect:rect
 //																	  barButtonItem:nil];			
@@ -448,7 +448,7 @@ shouldReloadTableForSearchString:(NSString *)searchString
 																	   data:[Sort descriptions]
 															  selectedIndex:[sort name]
 																	 target:self 
-																	 action:@selector(sortOrderWasSelected::) 
+																	 action:@selector(sortOrderWasSelected:element:)
 																	  title:@"Select Sort Order"
 																	   rect:CGRectZero
 															  barButtonItem:sender];			


### PR DESCRIPTION
Using named parameters to silence Xcode 4.6 warnings of type:
"... used as the name of the previous parameter rather than as part of the selector".

Note: There are alternatives (e.g. ignoring missing selector names), but, since naming the parameters is recommended in Apple's coding guidelines for Cocoa, this seems to be a good choice.
