### PR TITLE
Ignore blank lines from todo.txt file

### DIFF
--- a/Classes/TaskIo.m
+++ b/Classes/TaskIo.m
@@ -55,6 +55,10 @@
     int i = 0;
     while ((line = [reader readTrimmedLine])) {
         NSLog(@"read line %d: %@", i, line);
+        if ( ![line length] ) {
+            NSLog(@"Ignoring blank line at line number %d", i);
+            continue;
+        }
 		Task *task = [[Task alloc] initWithId:i withRawText:line];
         [items addObject:task];
 		[task release];


### PR DESCRIPTION
A simple fix to ignore blank lines within the todo.txt file, so they don't show up as blank entries within the app. This mimics the list view from the command line app.
