### PR TITLE
Issue #168: Ignore blank lines from todo.txt file

### DIFF
--- a/Classes/TaskIo.m
+++ b/Classes/TaskIo.m
@@ -49,19 +49,28 @@
 @implementation TaskIo
 
 + (NSMutableArray*) loadTasksFromFile:(NSString*)filename {
+    DDFileReader *reader = [[DDFileReader alloc] initWithFilePath:filename];
+    NSMutableArray *items = [TaskIo loadTasksFromReader:reader];
+    [reader release];
+    return items;
+}
+
++ (NSMutableArray*) loadTasksFromReader:(DDFileReader*)reader {
     NSMutableArray *items = [NSMutableArray arrayWithCapacity:32];
-    DDFileReader * reader = [[DDFileReader alloc] initWithFilePath:filename];
     NSString * line = nil;
     int i = 0;
     while ((line = [reader readTrimmedLine])) {
         NSLog(@"read line %d: %@", i, line);
+        if ( ![line length] ) {
+            NSLog(@"Ignoring blank line at line number %d", i);
+            continue;
+        }
 		Task *task = [[Task alloc] initWithId:i withRawText:line];
         [items addObject:task];
 		[task release];
         i++;
     }
-    [reader release];    
-    
+
     return items;
 }
 

--- a/Todo-txt-unit-tests/TaskIoTest.h
+++ b/Todo-txt-unit-tests/TaskIoTest.h
@@ -3,7 +3,7 @@
  *
  * @author Todo.txt contributors <todotxt@yahoogroups.com>
  * @copyright 2011-2012 Todo.txt contributors (http://todotxt.com)
- *  
+ *
  * Dual-licensed under the GNU General Public License and the MIT License
  *
  * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
@@ -42,16 +42,8 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#import <SenTestingKit/SenTestingKit.h>
 
-#import <Foundation/Foundation.h>
-#import "DDFileReader.h"
-
-@interface TaskIo : NSObject {
-    
-}
-
-+ (NSMutableArray*) loadTasksFromFile:(NSString*)file;
-+ (NSMutableArray*) loadTasksFromReader:(DDFileReader*)reader;
-+ (void) writeTasks:(NSArray*)tasks toFile:(NSString*)filename overwrite:(BOOL)overwrite withWindowsBreaks:(BOOL)useWindowsBreaks;
+@interface TaskIoTest : SenTestCase
 
 @end

--- a/Todo-txt-unit-tests/TaskIoTest.m
+++ b/Todo-txt-unit-tests/TaskIoTest.m
@@ -3,7 +3,7 @@
  *
  * @author Todo.txt contributors <todotxt@yahoogroups.com>
  * @copyright 2011-2012 Todo.txt contributors (http://todotxt.com)
- *  
+ *
  * Dual-licensed under the GNU General Public License and the MIT License
  *
  * @license GNU General Public License http://www.gnu.org/licenses/gpl.html
@@ -42,16 +42,66 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-
-#import <Foundation/Foundation.h>
+#import "TaskIo.h"
+#import "TaskIoTest.h"
 #import "DDFileReader.h"
 
-@interface TaskIo : NSObject {
-    
+@interface MockDDReader : DDFileReader
+@property int counter;
+@property (assign) NSArray *lines;
+
+- (id)initWithStrings:(NSArray *) lines;
+@end
+
+@implementation MockDDReader
+
+- (id)initWithStrings: (NSArray *) lines {
+    self = [super init];
+    if (self) {
+        _counter = 0;
+        _lines = lines;
+    }
+    return self;
 }
 
-+ (NSMutableArray*) loadTasksFromFile:(NSString*)file;
-+ (NSMutableArray*) loadTasksFromReader:(DDFileReader*)reader;
-+ (void) writeTasks:(NSArray*)tasks toFile:(NSString*)filename overwrite:(BOOL)overwrite withWindowsBreaks:(BOOL)useWindowsBreaks;
+-(NSString *)readTrimmedLine {
+
+    if( _counter >= [_lines count] )
+    {
+        return nil;
+    }
+
+    NSString *val = [_lines objectAtIndex: _counter];
+    _counter++;
+
+    return val;
+}
+@end
+
+@implementation TaskIoTest
+
+- (void)testNoLines
+{
+    MockDDReader *reader = [[MockDDReader alloc] initWithStrings:[[NSArray alloc] init]];
+    NSMutableArray *items = [TaskIo loadTasksFromReader:reader];
+
+    STAssertEquals([items count], 0u, @"Expecting 2 items");
+
+    [reader release];
+}
+
+- (void)testIgnoreBlankLines
+{
+    NSArray *lines = [[NSArray alloc] initWithObjects:@"First line", @"", @"Second line", @"", nil];
+    MockDDReader *reader = [[MockDDReader alloc] initWithStrings:lines];
+    NSMutableArray *items = [TaskIo loadTasksFromReader:reader];
+
+    STAssertEquals([items count], 2u, @"Expecting 2 items");
+    STAssertEqualObjects([[items objectAtIndex:0u] text], @"First line", @"Expecting 'First line'");
+    STAssertEqualObjects([[items objectAtIndex:1u] text], @"Second line", @"Expecting 'Second line'");
+
+    [reader release];
+    [lines release];
+}
 
 @end

--- a/todo.txt-touch-ios.xcodeproj/project.pbxproj
+++ b/todo.txt-touch-ios.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		59216BFF13E7804700FF07EE /* TaskEditViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 59216BFD13E7804700FF07EE /* TaskEditViewController.m */; };
 		59216C7513E8C89200FF07EE /* Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 59216C7413E8C89200FF07EE /* Util.m */; };
 		59216D3E13EA318100FF07EE /* RelativeDate.m in Sources */ = {isa = PBXBuildFile; fileRef = 59216D3D13EA318100FF07EE /* RelativeDate.m */; };
+		7B06BDC917A320880001CCB6 /* TaskIoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B06BDC817A320880001CCB6 /* TaskIoTest.m */; };
 		7D57054712F89F1900BB5E8D /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 7D57054312F89F1900BB5E8D /* Icon-72.png */; };
 		7D57054812F89F1900BB5E8D /* Icon-Small-50.png in Resources */ = {isa = PBXBuildFile; fileRef = 7D57054412F89F1900BB5E8D /* Icon-Small-50.png */; };
 		7D57054912F89F1900BB5E8D /* Icon-Small.png in Resources */ = {isa = PBXBuildFile; fileRef = 7D57054512F89F1900BB5E8D /* Icon-Small.png */; };
@@ -266,6 +267,8 @@
 		59216C7413E8C89200FF07EE /* Util.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Util.m; sourceTree = "<group>"; };
 		59216D3C13EA318100FF07EE /* RelativeDate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelativeDate.h; sourceTree = "<group>"; };
 		59216D3D13EA318100FF07EE /* RelativeDate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RelativeDate.m; sourceTree = "<group>"; };
+		7B06BDC717A320880001CCB6 /* TaskIoTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaskIoTest.h; sourceTree = "<group>"; };
+		7B06BDC817A320880001CCB6 /* TaskIoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TaskIoTest.m; sourceTree = "<group>"; };
 		7D57054312F89F1900BB5E8D /* Icon-72.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-72.png"; sourceTree = "<group>"; };
 		7D57054412F89F1900BB5E8D /* Icon-Small-50.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-Small-50.png"; sourceTree = "<group>"; };
 		7D57054512F89F1900BB5E8D /* Icon-Small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-Small.png"; sourceTree = "<group>"; };
@@ -818,6 +821,8 @@
 				8876EF5F14AD7D3E00F28C3C /* StringsTest.m */,
 				0F75B421149912DF00848E27 /* TaskUtilTest.h */,
 				0F75B423149912DF00848E27 /* TaskUtilTest.m */,
+				7B06BDC717A320880001CCB6 /* TaskIoTest.h */,
+				7B06BDC817A320880001CCB6 /* TaskIoTest.m */,
 			);
 			name = Util;
 			sourceTree = "<group>";
@@ -1120,6 +1125,7 @@
 				88E5140E14D3948F00177F45 /* DropboxFileUploaderTest.m in Sources */,
 				88E5141114D3969D00177F45 /* AsyncWaiter.m in Sources */,
 				88E5141414D50C7600177F45 /* TaskBagImplTest.m in Sources */,
+				7B06BDC917A320880001CCB6 /* TaskIoTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Implement a simple fix that skips blank lines read in from the todo.txt file. Included is a unit test that verifies proper output from TaskIo loadTasksFromFile.
