### PR TITLE
Unset extending under top and bottom bars for all view controllers.

### DIFF
--- a/MainStoryboard_iPad.storyboard
+++ b/MainStoryboard_iPad.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4510" systemVersion="12F37" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="q98-oM-s57">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4510" systemVersion="12F45" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="q98-oM-s57">
     <dependencies>
         <deployment defaultVersion="1536" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
@@ -146,10 +146,10 @@
             </objects>
             <point key="canvasLocation" x="2226" y="288"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Opaque Bars Navigation Controller-->
         <scene sceneID="ip1-CR-TYL">
             <objects>
-                <navigationController definesPresentationContext="YES" hidesBottomBarWhenPushed="YES" id="kdV-Nh-Ir7" sceneMemberID="viewController">
+                <navigationController definesPresentationContext="YES" hidesBottomBarWhenPushed="YES" id="kdV-Nh-Ir7" customClass="OpaqueBarsNavigationController" sceneMemberID="viewController">
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="cRF-Z4-XdE">
                         <autoresizingMask key="autoresizingMask"/>
@@ -213,10 +213,10 @@
             </objects>
             <point key="canvasLocation" x="3084" y="-871"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Opaque Bars Navigation Controller-->
         <scene sceneID="gaI-AA-LUu">
             <objects>
-                <navigationController definesPresentationContext="YES" toolbarHidden="NO" id="IRl-Mb-hwh" sceneMemberID="viewController">
+                <navigationController definesPresentationContext="YES" toolbarHidden="NO" id="IRl-Mb-hwh" customClass="OpaqueBarsNavigationController" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="dHl-9C-0uz">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -232,10 +232,10 @@
             </objects>
             <point key="canvasLocation" x="433" y="288"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Opaque Bars Navigation Controller-->
         <scene sceneID="ss7-dU-ZOS">
             <objects>
-                <navigationController id="jSC-c6-Vml" sceneMemberID="viewController">
+                <navigationController id="jSC-c6-Vml" customClass="OpaqueBarsNavigationController" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="Vzv-q0-ktc">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/MainStoryboard_iPad.storyboard
+++ b/MainStoryboard_iPad.storyboard
@@ -10,7 +10,7 @@
             <objects>
                 <tableViewController clearsSelectionOnViewWillAppear="NO" id="n6D-qk-G6m" customClass="FilterViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="2gC-So-frt">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="852"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="788"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <connections>
@@ -18,6 +18,7 @@
                             <outlet property="delegate" destination="n6D-qk-G6m" id="dUe-qU-dB2"/>
                         </connections>
                     </tableView>
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationItem key="navigationItem" id="dO2-cj-bR2">
                         <nil key="title"/>
                         <segmentedControl key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="TAk-NK-2H4">
@@ -43,11 +44,11 @@
             <objects>
                 <tableViewController id="HNI-em-gnU" customClass="TasksViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="qDN-97-LEn" customClass="PGTableViewWithEmptyView">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                        <rect key="frame" x="0.0" y="64" width="768" height="916"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <searchBar key="tableHeaderView" contentMode="redraw" id="0yi-6g-kYU">
-                            <rect key="frame" x="0.0" y="64" width="768" height="44"/>
+                            <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <textInputTraits key="textInputTraits"/>
                             <connections>
@@ -58,6 +59,7 @@
                             <outlet property="emptyView" destination="6ej-HE-d4g" id="0Tr-tQ-emG"/>
                         </connections>
                     </tableView>
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <toolbarItems>
                         <barButtonItem title="Sort" id="zmD-dM-QFr">
                             <connections>
@@ -126,7 +128,7 @@
             <objects>
                 <tableViewController hidesBottomBarWhenPushed="YES" id="Z53-s2-uc1" customClass="TaskViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="MaW-ZS-AKU">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                        <rect key="frame" x="0.0" y="64" width="768" height="916"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <connections>
@@ -134,6 +136,7 @@
                             <outlet property="delegate" destination="Z53-s2-uc1" id="E58-vF-qsP"/>
                         </connections>
                     </tableView>
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationItem key="navigationItem" id="ikx-Ac-dQh"/>
                     <connections>
                         <segue destination="kdV-Nh-Ir7" kind="modal" identifier="TaskEditSegue" modalTransitionStyle="coverVertical" id="I3C-Wc-7PQ"/>
@@ -147,6 +150,7 @@
         <scene sceneID="ip1-CR-TYL">
             <objects>
                 <navigationController definesPresentationContext="YES" hidesBottomBarWhenPushed="YES" id="kdV-Nh-Ir7" sceneMemberID="viewController">
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="cRF-Z4-XdE">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -340,6 +344,6 @@
         <simulatedScreenMetrics key="destination"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
-        <segue reference="Fka-eT-1jp"/>
+        <segue reference="I3C-Wc-7PQ"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/MainStoryboard_iPhone.storyboard
+++ b/MainStoryboard_iPhone.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4510" systemVersion="12F37" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="qhX-d2-2Zl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4510" systemVersion="12F45" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="qhX-d2-2Zl">
     <dependencies>
         <deployment defaultVersion="1536" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
@@ -115,10 +115,10 @@
             </objects>
             <point key="canvasLocation" x="921" y="837"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Opaque Bars Navigation Controller-->
         <scene sceneID="OSl-2d-rhE">
             <objects>
-                <navigationController definesPresentationContext="YES" hidesBottomBarWhenPushed="YES" id="RPp-ft-Qyc" sceneMemberID="viewController">
+                <navigationController definesPresentationContext="YES" hidesBottomBarWhenPushed="YES" id="RPp-ft-Qyc" customClass="OpaqueBarsNavigationController" sceneMemberID="viewController">
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="BZt-qo-Qm6">
                         <autoresizingMask key="autoresizingMask"/>
@@ -182,10 +182,10 @@
             </objects>
             <point key="canvasLocation" x="1719" y="142"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Opaque Bars Navigation Controller-->
         <scene sceneID="wQF-xA-cys">
             <objects>
-                <navigationController definesPresentationContext="YES" toolbarHidden="NO" id="qhX-d2-2Zl" sceneMemberID="viewController">
+                <navigationController definesPresentationContext="YES" toolbarHidden="NO" id="qhX-d2-2Zl" customClass="OpaqueBarsNavigationController" sceneMemberID="viewController">
                     <keyCommands/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ohO-Dh-qaI">
                         <autoresizingMask key="autoresizingMask"/>
@@ -301,10 +301,10 @@
             </objects>
             <point key="canvasLocation" x="1359" y="-553"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Opaque Bars Navigation Controller-->
         <scene sceneID="QUm-lo-bSV">
             <objects>
-                <navigationController definesPresentationContext="YES" id="ljP-8d-Aeg" sceneMemberID="viewController">
+                <navigationController definesPresentationContext="YES" id="ljP-8d-Aeg" customClass="OpaqueBarsNavigationController" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="yMu-f2-x6Q">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/MainStoryboard_iPhone.storyboard
+++ b/MainStoryboard_iPhone.storyboard
@@ -10,11 +10,11 @@
             <objects>
                 <tableViewController id="yWi-bb-L3m" customClass="TasksViewController" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="C2e-rl-6C1" customClass="PGTableViewWithEmptyView">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="460"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <searchBar key="tableHeaderView" contentMode="redraw" id="nbM-XI-PVk">
-                            <rect key="frame" x="0.0" y="64" width="320" height="44"/>
+                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <textInputTraits key="textInputTraits"/>
                             <connections>
@@ -25,6 +25,7 @@
                             <outlet property="emptyView" destination="HcP-t0-btj" id="flc-Ie-JBx"/>
                         </connections>
                     </tableView>
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <toolbarItems>
                         <barButtonItem title="Sort" id="zDX-AB-di9">
                             <connections>
@@ -118,6 +119,7 @@
         <scene sceneID="OSl-2d-rhE">
             <objects>
                 <navigationController definesPresentationContext="YES" hidesBottomBarWhenPushed="YES" id="RPp-ft-Qyc" sceneMemberID="viewController">
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="BZt-qo-Qm6">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -184,6 +186,7 @@
         <scene sceneID="wQF-xA-cys">
             <objects>
                 <navigationController definesPresentationContext="YES" toolbarHidden="NO" id="qhX-d2-2Zl" sceneMemberID="viewController">
+                    <keyCommands/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ohO-Dh-qaI">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -214,7 +217,6 @@
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pkj-Ms-wIS">
                                 <rect key="frame" x="20" y="284" width="280" height="70"/>
-                                <rect key="frame" x="83" y="128" width="155" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="70" id="KbW-jt-O01"/>
                                     <constraint firstAttribute="width" constant="280" id="aTL-qH-Jf7"/>
@@ -264,10 +266,11 @@
             <objects>
                 <tableViewController id="ZMT-wH-wbl" customClass="FilterViewController" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="k99-Yx-ghR">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                     </tableView>
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationItem key="navigationItem" id="Vgd-rG-aQM">
                         <nil key="title"/>
                         <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="Cn3-XT-uuL">

--- a/View Controllers/OpaqueBarsNavigationController.h
+++ b/View Controllers/OpaqueBarsNavigationController.h
@@ -1,0 +1,13 @@
+//
+//  OpaqueBarsNavigationController.h
+//  todo.txt-touch-ios
+//
+//  Created by Brendon Justin on 10/5/13.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface OpaqueBarsNavigationController : UINavigationController
+
+@end

--- a/View Controllers/OpaqueBarsNavigationController.m
+++ b/View Controllers/OpaqueBarsNavigationController.m
@@ -1,0 +1,21 @@
+//
+//  OpaqueBarsNavigationController.m
+//  todo.txt-touch-ios
+//
+//  Created by Brendon Justin on 10/5/13.
+//
+//
+
+#import "OpaqueBarsNavigationController.h"
+
+@implementation OpaqueBarsNavigationController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    
+    self.navigationBar.translucent = NO;
+    self.toolbar.translucent = NO;
+}
+
+@end

--- a/todo.txt-touch-ios.xcodeproj/project.pbxproj
+++ b/todo.txt-touch-ios.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		5C8E05B517AD8A4700F238E2 /* DDFileReader.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CE4238A17A603EF009C6D25 /* DDFileReader.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		5C8E05B617AD8A6B00F238E2 /* libReactiveCocoa-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CC3F47517A6105C0096A989 /* libReactiveCocoa-iOS.a */; };
 		5C8E05B917AD8A8D00F238E2 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CE4238617A60396009C6D25 /* Reachability.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		5CBA12CB1800953500E55CE6 /* OpaqueBarsNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CBA12CA1800953500E55CE6 /* OpaqueBarsNavigationController.m */; };
 		5CC3F46617A60F2A0096A989 /* UIColor+CustomColors.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CC3F46517A60F2A0096A989 /* UIColor+CustomColors.m */; };
 		5CC3F46717A60F2A0096A989 /* UIColor+CustomColors.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CC3F46517A60F2A0096A989 /* UIColor+CustomColors.m */; };
 		5CC3F47C17A6107C0096A989 /* libReactiveCocoa-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CC3F47517A6105C0096A989 /* libReactiveCocoa-iOS.a */; };
@@ -277,6 +278,8 @@
 		5C402B6217EE981300DB3F84 /* dropbox_logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = dropbox_logo.png; sourceTree = "<group>"; };
 		5C402B6917EE9EB600DB3F84 /* green.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = green.png; sourceTree = "<group>"; };
 		5CA3274B17A6198F0089F9A1 /* DropboxApiKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DropboxApiKey.h; sourceTree = "<group>"; };
+		5CBA12C91800953500E55CE6 /* OpaqueBarsNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpaqueBarsNavigationController.h; sourceTree = "<group>"; };
+		5CBA12CA1800953500E55CE6 /* OpaqueBarsNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OpaqueBarsNavigationController.m; sourceTree = "<group>"; };
 		5CC3F46117A60EC70096A989 /* TaskBag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaskBag.h; sourceTree = "<group>"; };
 		5CC3F46217A60EC70096A989 /* TaskFilterTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaskFilterTarget.h; sourceTree = "<group>"; };
 		5CC3F46417A60F2A0096A989 /* UIColor+CustomColors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+CustomColors.h"; sourceTree = "<group>"; };
@@ -884,6 +887,8 @@
 				5CE423D017A60B6A009C6D25 /* FilterViewController.m */,
 				5CE4239517A60509009C6D25 /* LoginScreenViewController.h */,
 				5CE4239617A60509009C6D25 /* LoginScreenViewController.m */,
+				5CBA12C91800953500E55CE6 /* OpaqueBarsNavigationController.h */,
+				5CBA12CA1800953500E55CE6 /* OpaqueBarsNavigationController.m */,
 				5CE4239817A60509009C6D25 /* TaskEditViewController.h */,
 				5CE4239917A60509009C6D25 /* TaskEditViewController.m */,
 				5CE423D117A60B6A009C6D25 /* TasksViewController.h */,
@@ -1288,6 +1293,7 @@
 				88DB7C1D14B2C786003A96F9 /* ByContextFilter.m in Sources */,
 				88DB7C1F14B2C786003A96F9 /* ByPriorityFilter.m in Sources */,
 				88DB7C2114B2C786003A96F9 /* ByProjectFilter.m in Sources */,
+				5CBA12CB1800953500E55CE6 /* OpaqueBarsNavigationController.m in Sources */,
 				88DB7C2314B2C786003A96F9 /* ByTextFilter.m in Sources */,
 				88DB7C2514B2C786003A96F9 /* AndFilter.m in Sources */,
 				88DB7C2714B2C786003A96F9 /* OrFilter.m in Sources */,


### PR DESCRIPTION
Turns off extending under top and bottom bars for all views. While not the best solution, it does address #185.

I couldn't come up with a good way to set all navigation bars and toolbars as opaque, so they are a dismal shade of gray now :(. I'll look at making the bars white again soon, and add to this PR.

Fixes #185, but makes the app all gray.

Update: I turned off translucency for navigation bars and toolbars using a navigation controller subclass. They appear white again.
