### PR TITLE
Display version number on settings screen

### DIFF
--- a/InAppSettings.bundle/Root.inApp.plist
+++ b/InAppSettings.bundle/Root.inApp.plist
@@ -31,21 +31,19 @@
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
 		<dict>
-			<key>Type</key>
-			<string>PSMultiValueSpecifier</string>
-			<key>Title</key>
-			<string>Badge Count</string>
 			<key>DefaultValue</key>
 			<string>none</string>
 			<key>Key</key>
 			<string>badgeCount_preference</string>
-			<key>Values</key>
+			<key>ShortTitles</key>
 			<array>
-				<string>none</string>
-				<string>any</string>
-				<string>anyPriority</string>
-				<string>priorityA</string>
+				<string>None</string>
+				<string>All Open</string>
+				<string>Prioritized</string>
+				<string>Priority (A)	</string>
 			</array>
+			<key>Title</key>
+			<string>Badge Count</string>
 			<key>Titles</key>
 			<array>
 				<string>None</string>
@@ -53,12 +51,14 @@
 				<string>Prioritized tasks</string>
 				<string>Priority A tasks</string>
 			</array>
-			<key>ShortTitles</key>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Values</key>
 			<array>
-				<string>None</string>
-				<string>All Open</string>
-				<string>Prioritized</string>
-				<string>Priority (A)	</string>
+				<string>none</string>
+				<string>any</string>
+				<string>anyPriority</string>
+				<string>priorityA</string>
 			</array>
 		</dict>
 		<dict>
@@ -68,22 +68,22 @@
 			<string>PSGroupSpecifier</string>
 		</dict>
 		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Auto Archive</string>
-			<key>Key</key>
-			<string>auto_archive_preference</string>
 			<key>DefaultValue</key>
 			<false/>
+			<key>Key</key>
+			<string>auto_archive_preference</string>
+			<key>Title</key>
+			<string>Auto Archive</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
 		</dict>
 		<dict>
-			<key>Type</key>
-			<string>IASKButtonSpecifier</string>
-			<key>Title</key>
-			<string>Archive Now</string>
 			<key>Key</key>
 			<string>archive_button</string>
+			<key>Title</key>
+			<string>Archive Now</string>
+			<key>Type</key>
+			<string>IASKButtonSpecifier</string>
 		</dict>
 		<dict>
 			<key>Title</key>
@@ -128,10 +128,20 @@
 			<string>IASKButtonSpecifier</string>
 		</dict>
 		<dict>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
 			<key>Title</key>
 			<string>About</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<string>1.6</string>
+			<key>Key</key>
+			<string>version_string</string>
+			<key>Title</key>
+			<string>Version</string>
+			<key>Type</key>
+			<string>PSTitleValueSpecifier</string>
 		</dict>
 		<dict>
 			<key>Key</key>

--- a/todo.txt-touch-ios.xcodeproj/project.pbxproj
+++ b/todo.txt-touch-ios.xcodeproj/project.pbxproj
@@ -1067,6 +1067,7 @@
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
 				1D60588F0D05DD3D006BFB54 /* Frameworks */,
+				8854EF05180CB30800E7064A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1219,6 +1220,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+		};
+		8854EF05180CB30800E7064A /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#Set version number in the settings bundle for display to the user.\nversion=`/usr/libexec/PlistBuddy -c \"Print :CFBundleVersion\" $SRCROOT/todo_txt_touch_ios-Info.plist`\n/usr/libexec/PlistBuddy \"$SRCROOT/InAppSettings.bundle/Root.inApp.plist\" -c \"set :PreferenceSpecifiers:12:DefaultValue $version\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Added a 'Run Script' phase to the build process that puts the current build number into the settings bundle so it will be displayed on the settings screen.

In the simulator, I had to quit the simulator and do a clean build to get a new version to display. I'm guessing that the simulator caches the settings or maybe the app itself if no code has changed? Testing on an actual device would be useful.
