### PR TITLE
Fix crash on conflict

### DIFF
--- a/Classes/DropboxFileUploader.h
+++ b/Classes/DropboxFileUploader.h
@@ -49,7 +49,7 @@
 @class RACSignal;
 
 static NSInteger const kUploadConflictErrorCode = 001;
-static NSString * const kUploadConflictFileString = @"__kUploadConflictFileString";
+static NSString * const kUploadConflictFile = @"__kUploadConflictFile";
 
 @interface DropboxFileUploader : NSObject
 

--- a/Classes/DropboxFileUploader.m
+++ b/Classes/DropboxFileUploader.m
@@ -143,7 +143,7 @@
 			file.status = dbConflict;
             NSError *err = [NSError errorWithDomain:kRCErrorDomain
                                                code:kUploadConflictErrorCode
-                                           userInfo:@{ kUploadConflictFileString : file }];
+                                           userInfo:@{ kUploadConflictFile : file }];
             [self.subject sendError:err];
 			return;
 		}
@@ -179,7 +179,7 @@
 		file.status = dbConflict;
         NSError *err = [NSError errorWithDomain:kRCErrorDomain
                                            code:kUploadConflictErrorCode
-                                       userInfo:@{ kUploadConflictFileString : file }];
+                                       userInfo:@{ kUploadConflictFile : file }];
         [self.subject sendError:err];
 		return;
 	}

--- a/Classes/DropboxFileUploader.m
+++ b/Classes/DropboxFileUploader.m
@@ -173,7 +173,7 @@
 	
 	file.loadedMetadata = metadata;	
 
-	if (![metadata.path isEqualToString:destPath]) {
+	if ([metadata.path caseInsensitiveCompare:destPath] != NSOrderedSame) {
 		// If the uploaded remote path does not match our expected remotePath, 
 		// then a conflict occurred and we should announce the conflict to the user.
 		file.status = dbConflict;

--- a/Classes/DropboxRemoteClient.m
+++ b/Classes/DropboxRemoteClient.m
@@ -253,10 +253,10 @@
          } error:^(NSError *error) {
              NSError *err = nil;
              if (error.code == kUploadConflictErrorCode) {
-                 NSString *conflictFile = error.userInfo[kUploadConflictFileString];
+                 DropboxFile *conflictFile = error.userInfo[kUploadConflictFile];
                  err = [NSError errorWithDomain:kRCErrorDomain
                                            code:kRCErrorUploadConflict
-                                       userInfo:@{ kRCUploadConflictFileKey : conflictFile }];
+                                       userInfo:@{ kRCUploadConflictFileKey : conflictFile.remoteFile }];
                  [self.pushSubject sendError:err];
              } else {
                  // call remote client delegate function


### PR DESCRIPTION
This **_may**_ fix issues #191 and #192. 

[Someone on the mailing list](http://groups.yahoo.com/neo/groups/todotxt/conversations/topics/5255) mentioned that renaming their 'Todo' directory to 'todo' fixed the issue, reminding me of [this issue](https://github.com/ginatrapani/todo.txt-android/pull/283) we had with the Android app. Changing my directory to 'Todo' made the app think there was a conflict, then it crashed in the simulator while attempting to display the conflict error. 

So, there were two fixes here:
1. Do a case-insensitive comparison when checking for a conflict, just like we had to do for the Android app.
2. Fix the crash by passing a string to the method that was expecting one, instead of a DropboxFile object.
