### PR TITLE
Fix showing the login view on launch, if the user is not logged in.

### DIFF
--- a/Classes/TodoTxtAppDelegate.m
+++ b/Classes/TodoTxtAppDelegate.m
@@ -58,6 +58,7 @@
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 static NSString * const kLoginScreenSegueIdentifier = @"LoginScreenSegue";
+static NSString * const kLoginScreenSegueNotAnimatedIdentifier = @"LoginScreenSegueNotAnimated";
 
 @interface TodoTxtAppDelegate ()
 
@@ -95,8 +96,16 @@ static NSString * const kLoginScreenSegueIdentifier = @"LoginScreenSegue";
                            userInfo:@{ NSLocalizedDescriptionKey : @"No internet connection: Cannot sync with Dropbox right now." }];
 }
 
+- (void)presentLoginControllerAnimated:(BOOL)animated {
+    if (animated) {
+        [self.window.rootViewController performSegueWithIdentifier:kLoginScreenSegueIdentifier sender:self];
+    } else {
+        [self.window.rootViewController performSegueWithIdentifier:kLoginScreenSegueNotAnimatedIdentifier sender:self];
+    }
+}
+
 - (void) presentLoginController {
-    [self.window.rootViewController performSegueWithIdentifier:kLoginScreenSegueIdentifier sender:self];
+    [self presentLoginControllerAnimated:YES];
 }
 
 - (void) presentMainViewController {
@@ -172,9 +181,13 @@ static NSString * const kLoginScreenSegueIdentifier = @"LoginScreenSegue";
 											 selector:@selector(reachabilityChanged) 
 												 name:kReachabilityChangedNotification object:nil];
     
-	if (![self.remoteClientManager.currentClient isAuthenticated]) {
-		[self presentLoginController];
-	}
+    if (![self.remoteClientManager.currentClient isAuthenticated]) {
+        // Show the login view during the next iteration of the run loop.
+        // It is too early to show the view at this point.
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+            [self presentLoginControllerAnimated:YES];
+        }];
+    }
 	
 
     UIViewController *rootViewController = self.window.rootViewController;

--- a/MainStoryboard_iPad.storyboard
+++ b/MainStoryboard_iPad.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4510" systemVersion="12F45" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="q98-oM-s57">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="q98-oM-s57">
     <dependencies>
         <deployment defaultVersion="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3746"/>
     </dependencies>
     <scenes>
         <!--Filter View Controller-->
@@ -256,6 +256,7 @@
                         <segue destination="jSC-c6-Vml" kind="relationship" relationship="masterViewController" id="uWB-sk-edw"/>
                         <segue destination="IRl-Mb-hwh" kind="relationship" relationship="detailViewController" id="KgM-FW-LLZ"/>
                         <segue destination="e5C-aC-Aod" kind="modal" identifier="LoginScreenSegue" id="qYf-co-8Dz"/>
+                        <segue destination="e5C-aC-Aod" kind="modal" identifier="LoginScreenSegueNotAnimated" animates="NO" id="0C1-Ko-UCJ"/>
                     </connections>
                 </splitViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4YP-fk-KXC" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -344,6 +345,7 @@
         <simulatedScreenMetrics key="destination"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
+        <segue reference="0C1-Ko-UCJ"/>
         <segue reference="I3C-Wc-7PQ"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/MainStoryboard_iPhone.storyboard
+++ b/MainStoryboard_iPhone.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4510" systemVersion="12F45" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="qhX-d2-2Zl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="qhX-d2-2Zl">
     <dependencies>
         <deployment defaultVersion="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3746"/>
     </dependencies>
     <scenes>
         <!--Tasks View Controller - Tasks-->
@@ -197,6 +197,7 @@
                     <connections>
                         <segue destination="yWi-bb-L3m" kind="relationship" relationship="rootViewController" id="Jpc-cP-1lu"/>
                         <segue destination="zny-pe-jlQ" kind="modal" identifier="LoginScreenSegue" id="mTv-lJ-sC6"/>
+                        <segue destination="zny-pe-jlQ" kind="modal" identifier="LoginScreenSegueNotAnimated" animates="NO" id="nZn-YM-cqf"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UUg-lD-lrW" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -328,6 +329,7 @@
         <simulatedScreenMetrics key="destination" type="retina4"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
+        <segue reference="nZn-YM-cqf"/>
         <segue reference="pCm-z6-2l4"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
Also add a segue to present the login view without animation.

Fixes #211.

This shows the tasks view before presenting the login view. Different behavior will require a more significant change.
