### PR TITLE
Restore network logic that didn't use ReactiveCocoa

### DIFF
--- a/Classes/DropboxFileDownloader.h
+++ b/Classes/DropboxFileDownloader.h
@@ -47,13 +47,13 @@
 #import <DropboxSDK/DropboxSDK.h>
 #import "DropboxFile.h"
 
-@class RACSignal;
-
 @interface DropboxFileDownloader : NSObject
 
 @property (nonatomic, readonly) NSArray *files;
+@property (nonatomic, readonly) DropboxFileStatus status;
 @property (nonatomic, readonly) NSError *error;
 
-- (RACSignal *)pullFiles:(NSArray *)dropboxFiles;
+- (id) initWithTarget:(id)aTarget onComplete:(SEL)selector;
+- (void) pullFiles:(NSArray*)dropboxFiles;
 
 @end

--- a/Classes/DropboxFileUploader.h
+++ b/Classes/DropboxFileUploader.h
@@ -46,8 +46,6 @@
 #import <DropboxSDK/DropboxSDK.h>
 #import "DropboxFile.h"
 
-@class RACSignal;
-
 static NSInteger const kUploadConflictErrorCode = 001;
 static NSString * const kUploadConflictFile = @"__kUploadConflictFile";
 
@@ -55,8 +53,10 @@ static NSString * const kUploadConflictFile = @"__kUploadConflictFile";
 
 @property (nonatomic, readonly) BOOL overwrite;
 @property (nonatomic, readonly) NSArray *files;
+@property (nonatomic, readonly) DropboxFileStatus status;
 @property (nonatomic, readonly) NSError *error;
 
-- (RACSignal *)pushFiles:(NSArray*)dropboxFiles overwrite:(BOOL)overwrite;
+- (id) initWithTarget:(id)aTarget onComplete:(SEL)selector;
+- (void) pushFiles:(NSArray*)dropboxFiles overwrite:(BOOL)overwrite;
 
 @end

--- a/Classes/DropboxRemoteClient.m
+++ b/Classes/DropboxRemoteClient.m
@@ -49,15 +49,10 @@
 #import "Util.h"
 #import "DropboxFile.h"
 
-#import <ReactiveCocoa/ReactiveCocoa.h>
-
 #define TODO_TXT @"todo.txt"
 #define DONE_TXT @"done.txt"
 
 @interface DropboxRemoteClient () <DBSessionDelegate>
-
-@property (nonatomic, strong) RACSubject *pullSubject;
-@property (atomic, strong) RACSubject *pushSubject;
 
 @property (nonatomic, strong) DropboxFileDownloader *downloader;
 @property (nonatomic, strong) DropboxFileUploader *uploader;
@@ -133,146 +128,136 @@
 	[[DBSession sharedSession] linkFromController:(UIViewController*)parentViewController];
 }
 
-- (RACSignal *)pullTodo {
-    self.pullSubject = [RACSubject subject];
-    
-    // Always run on the main thread
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-        // Quit without taking any action if the network is not available
-        if (![self isNetworkAvailable]) {
-            [self.pullSubject sendCompleted];
-            return;
-        }
-        
-        DropboxFileDownloader* todoDownloader = [[DropboxFileDownloader alloc] init];
-        [[todoDownloader pullFiles:@[
-                                     [[DropboxFile alloc] initWithRemoteFile:[DropboxRemoteClient todoTxtRemoteFile]
-                                                                   localFile:[DropboxRemoteClient todoTxtTmpFile]
-                                                                 originalRev:[[NSUserDefaults standardUserDefaults] stringForKey:@"dropbox_last_rev"]],
-                                     [[DropboxFile alloc] initWithRemoteFile:[DropboxRemoteClient doneTxtRemoteFile]
-                                                                   localFile:[DropboxRemoteClient doneTxtTmpFile]
-                                                                 originalRev:[[NSUserDefaults standardUserDefaults] stringForKey:@"dropbox_last_rev_done"]],
-                                     ]]
-         subscribeNext:^(NSArray *files) {
-             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-             DropboxFile *todoFile = files[0];
-             DropboxFile *doneFile = files[1];
-             
-             // save revs
-             if (todoFile.status == dbSuccess) {
-                 [defaults setValue:todoFile.loadedMetadata.rev forKey:@"dropbox_last_rev"];
-             }
-             if (doneFile.status == dbSuccess) {
-                 [defaults setValue:doneFile.loadedMetadata.rev forKey:@"dropbox_last_rev_done"];
-             }
-             
-             NSString *loadedTodoFile = nil;
-             if (todoFile.status == dbSuccess) {
-                 loadedTodoFile = todoFile.localFile;
-             }
-             NSString *loadedDoneFile = nil;
-             if (doneFile.status == dbSuccess) {
-                 loadedDoneFile = doneFile.localFile;
-             }
-             
-             // report status upstream
-             NSArray *loadedFiles = @[];
-             if (loadedTodoFile) {
-                 loadedFiles = [loadedFiles arrayByAddingObject:loadedTodoFile];
-             }
-             
-             if (loadedDoneFile) {
-                 loadedFiles = [loadedFiles arrayByAddingObject:loadedDoneFile];
-             }
-             
-             [self.pullSubject sendNext:loadedFiles];
-             [self.pullSubject sendCompleted];
-         } error:^(NSError *error) {
-             // report error upstream
-             [self.pullSubject sendError:error];
-         }];
-        
-        // hang onto todoDownloader so it doesn't get dealloc'ed
-        self.downloader = todoDownloader;
-    }];
-    
-    return self.pullSubject;
+- (void)pullTodoCompleted:(DropboxFileDownloader*)todoDownloader {
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	DropboxFile *todoFile = [todoDownloader.files objectAtIndex:0];
+	DropboxFile *doneFile = [todoDownloader.files objectAtIndex:1];
+	
+	if (todoDownloader.status == dbSuccess) {
+		// save revs
+		if (todoFile.status == dbSuccess) {
+			[defaults setValue:todoFile.loadedMetadata.rev forKey:@"dropbox_last_rev"];
+		}
+		if (doneFile.status == dbSuccess) {
+			[defaults setValue:doneFile.loadedMetadata.rev forKey:@"dropbox_last_rev_done"];
+		}
+	}
+	
+	if (todoDownloader.status != dbError) {
+		NSString *loadedTodoFile = nil;
+		if (todoFile.status == dbSuccess) {
+			loadedTodoFile = todoFile.localFile;
+		}
+		NSString *loadedDoneFile = nil;
+		if (doneFile.status == dbSuccess) {
+			loadedDoneFile = doneFile.localFile;
+		}
+		
+		// report status upstream
+		if (self.delegate && [self.delegate respondsToSelector:@selector(remoteClient:loadedTodoFile:loadedDoneFile:)]) {
+			[self.delegate remoteClient:self loadedTodoFile:loadedTodoFile loadedDoneFile:loadedDoneFile];
+		}
+	} else {
+		// report error upstream
+		if (self.delegate && [self.delegate respondsToSelector:@selector(remoteClient:loadFileFailedWithError:)]) {
+			[self.delegate remoteClient:self loadFileFailedWithError:todoDownloader.error];
+		}
+	}
 }
 
-- (RACSignal *)pushTodoOverwrite:(BOOL)doOverwrite withTodo:(NSString*)todoPath withDone:(NSString*)donePath {
-    self.pushSubject = [RACSubject subject];
+- (void)pullTodo {
+	if (![NSThread isMainThread]) {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self pullTodo];
+		});
+		return;
+	}
+
+	if (![self isNetworkAvailable]) {
+		return;
+	}
+	
+    DropboxFileDownloader* todoDownloader = [[DropboxFileDownloader alloc] initWithTarget:self
+                                                                               onComplete:@selector(pullTodoCompleted:)];
+	[todoDownloader pullFiles:[NSArray arrayWithObjects:[[DropboxFile alloc] initWithRemoteFile:[DropboxRemoteClient todoTxtRemoteFile]
+														   localFile:[DropboxRemoteClient todoTxtTmpFile]
+														originalRev:[[NSUserDefaults standardUserDefaults] stringForKey:@"dropbox_last_rev"]],
+							  [[DropboxFile alloc] initWithRemoteFile:[DropboxRemoteClient doneTxtRemoteFile]
+														   localFile:[DropboxRemoteClient doneTxtTmpFile]
+														originalRev:[[NSUserDefaults standardUserDefaults] stringForKey:@"dropbox_last_rev_done"]],
+							  nil]];
     
-    // Always run on the main thread
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-        // Quit without taking any action if the network is not available
-        if (![self isNetworkAvailable]) {
-            [self.pushSubject sendCompleted];
-            return;
-        }
-        
-        NSMutableArray *files = [NSMutableArray arrayWithCapacity:2];
-        if (todoPath) {
-            [files addObject:[[DropboxFile alloc] initWithRemoteFile:[DropboxRemoteClient todoTxtRemoteFile]
-                                                           localFile:todoPath
-                                                         originalRev:[[NSUserDefaults standardUserDefaults] stringForKey:@"dropbox_last_rev"]]];
-        }
-        
-        if (donePath) {
-            [files addObject:[[DropboxFile alloc] initWithRemoteFile:[DropboxRemoteClient doneTxtRemoteFile]
-                                                           localFile:donePath
-                                                         originalRev:[[NSUserDefaults standardUserDefaults] stringForKey:@"dropbox_last_rev_done"]]];
-        }
-        
-        DropboxFileUploader* todoUploader = [[DropboxFileUploader alloc] init];
-        
-        [[todoUploader pushFiles:files overwrite:doOverwrite]
-         subscribeNext:^(NSArray *files) {
-             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-             DropboxFile *todoFile = files[0];
-             DropboxFile *doneFile = nil;
-             if (files.count > 1) {
-                 doneFile = files[1];
-             }
-             
-             // save revs
-             [defaults setValue:todoFile.loadedMetadata.rev forKey:@"dropbox_last_rev"];
-             if (doneFile) {
-                 [defaults setValue:doneFile.loadedMetadata.rev forKey:@"dropbox_last_rev_done"];
-             }
-             
-             NSArray *pushArray = @[];
-             if (todoFile.remoteFile) {
-                 pushArray = [pushArray arrayByAddingObject:todoFile.remoteFile];
-             }
-             
-             if (doneFile.remoteFile) {
-                 pushArray = [pushArray arrayByAddingObject:doneFile.remoteFile];
-             }
-             
-             [self.pushSubject sendNext:pushArray];
-         } error:^(NSError *error) {
-             NSError *err = nil;
-             if (error.code == kUploadConflictErrorCode) {
-                 DropboxFile *conflictFile = error.userInfo[kUploadConflictFile];
-                 err = [NSError errorWithDomain:kRCErrorDomain
-                                           code:kRCErrorUploadConflict
-                                       userInfo:@{ kRCUploadConflictFileKey : conflictFile.remoteFile }];
-                 [self.pushSubject sendError:err];
-             } else {
-                 // call remote client delegate function
-                 
-                 err = [NSError errorWithDomain:kRCErrorDomain
-                                           code:kRCErrorUploadFailed
-                                       userInfo:nil];
-                 [self.pushSubject sendError:err];
-             }
-         }];
-        
-        // hang onto todoUploader so it doesn't get dealloc'ed
-        self.uploader = todoUploader;
-    }];
+    // hang onto todoDownloader so it doesn't get dealloc'ed
+    self.downloader = todoDownloader;
+}
+
+- (void)pushTodoCompleted:(DropboxFileUploader*)todoUploader {
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	DropboxFile *todoFile = [todoUploader.files objectAtIndex:0];
+	DropboxFile *doneFile = nil;
+	if (todoUploader.files.count > 1) {
+		doneFile = [todoUploader.files objectAtIndex:1];
+	}
+	
+	if (todoUploader.status == dbSuccess) {
+		// save revs
+		[defaults setValue:todoFile.loadedMetadata.rev forKey:@"dropbox_last_rev"];
+		if (doneFile) [defaults setValue:doneFile.loadedMetadata.rev forKey:@"dropbox_last_rev_done"];
+	}
+	
+	if (todoUploader.status == dbError) {
+		// call remote client delegate function
+		if (self.delegate && [self.delegate respondsToSelector:@selector(remoteClient:uploadFileFailedWithError:)]) {
+			[self.delegate remoteClient:self uploadFileFailedWithError:todoUploader.error];
+		}
+	} else if (todoUploader.status == dbConflict) {
+		NSString *conflictFile = nil;
+		if (todoFile.status == dbConflict) {
+			conflictFile = todoFile.remoteFile;
+		} else if (doneFile && doneFile.status == dbConflict) {
+			conflictFile = doneFile.remoteFile;
+		}
+		if (self.delegate && [self.delegate respondsToSelector:@selector(remoteClient:uploadFileFailedWithConflict:)]) {
+			[self.delegate remoteClient:self uploadFileFailedWithConflict:conflictFile];
+		}
+	} else {
+		if (self.delegate && [self.delegate respondsToSelector:@selector(remoteClient:uploadedFile:)]) {
+			[self.delegate remoteClient:self uploadedFile:todoFile.remoteFile];
+		}
+	}
+}
+
+- (void)pushTodoOverwrite:(BOOL)doOverwrite withTodo:(NSString*)todoPath withDone:(NSString*)donePath {
+	if (![NSThread isMainThread]) {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self pushTodoOverwrite:doOverwrite withTodo:todoPath withDone:donePath];
+		});
+		return;
+	}
+
+	if (![self isNetworkAvailable]) {
+		return;
+	}
+	
+	NSMutableArray *files = [NSMutableArray arrayWithCapacity:2];
+	if (todoPath) {
+		[files addObject:[[DropboxFile alloc] initWithRemoteFile:[DropboxRemoteClient todoTxtRemoteFile]
+													  localFile:todoPath
+													 originalRev:[[NSUserDefaults standardUserDefaults] stringForKey:@"dropbox_last_rev"]]];
+	}
+
+	if (donePath) {
+		[files addObject:[[DropboxFile alloc] initWithRemoteFile:[DropboxRemoteClient doneTxtRemoteFile]
+													   localFile:donePath
+													 originalRev:[[NSUserDefaults standardUserDefaults] stringForKey:@"dropbox_last_rev_done"]]];
+	}
+
+    DropboxFileUploader* todoUploader = [[DropboxFileUploader alloc] initWithTarget:self
+                                                    onComplete:@selector(pushTodoCompleted:)];
+    [todoUploader pushFiles:files overwrite:doOverwrite];
     
-    return self.pushSubject;
+    // hang onto todoUploader so it doesn't get dealloc'ed
+    self.uploader = todoUploader;
 }
 
 - (BOOL) isNetworkAvailable {

--- a/Classes/RemoteClient.h
+++ b/Classes/RemoteClient.h
@@ -53,19 +53,17 @@ static NSString * const kRCUploadConflictFileKey = @"__kRCUploadConflictFileKey"
 static NSInteger const kRCErrorUploadConflict = 001;
 static NSInteger const kRCErrorUploadFailed = 002;
 
-@class RACSignal;
-
 @protocol RemoteClientDelegate;
 
 @protocol RemoteClient <NSObject> 
 
-- (Client)client;
+- (Client) client;
 - (BOOL)authenticate;
 - (void)deauthenticate;
 - (BOOL)isAuthenticated;
 - (void)presentLoginControllerFromController:(UIViewController*)parentViewController;
-- (RACSignal *)pullTodo;
-- (RACSignal *)pushTodoOverwrite:(BOOL)doOverwrite withTodo:(NSString*)todoPath withDone:(NSString*)donePath;
+- (void)pullTodo;
+- (void)pushTodoOverwrite:(BOOL)doOverwrite withTodo:(NSString*)todoPath withDone:(NSString*)donePath;
 - (BOOL)isNetworkAvailable;
 - (BOOL)handleOpenURL:(NSURL *)url;
 
@@ -76,6 +74,12 @@ static NSInteger const kRCErrorUploadFailed = 002;
 
 @protocol RemoteClientDelegate <NSObject>
 
+- (void)remoteClient:(id<RemoteClient>)client loadedTodoFile:(NSString*)todoPath loadedDoneFile:(NSString*)donePath;
+- (void)remoteClient:(id<RemoteClient>)client loadFileFailedWithError:(NSError*)error;
+- (void)remoteClient:(id<RemoteClient>)client uploadedFile:(NSString*)destPath;
+- (void)remoteClient:(id<RemoteClient>)client uploadFileFailedWithError:(NSError*)error;
+- (void)remoteClient:(id<RemoteClient>)client uploadFileFailedWithConflict:(NSString*)destPath;
 - (void)remoteClient:(id<RemoteClient>)client loginControllerDidLogin:(BOOL)success;
+
 
 @end

--- a/Classes/TodoTxtAppDelegate.h
+++ b/Classes/TodoTxtAppDelegate.h
@@ -49,10 +49,18 @@
 
 static NSString * const kTODOErrorDomain = @"com.todotxt.Todo-txt";
 static NSInteger const kTODOErrorCodeNoInternet = 101;
+static NSInteger const kTODOErrorCodeFileConflict = 102;
 static NSInteger const kTODOErrorCodeDownloadError = 201;
 static NSInteger const kTODOErrorCodeUploadError = 202;
 
-@class RACSignal, RACSubject;
+/// Key in the userInfo dictionary for errors passed along with sync finish notifications.
+extern NSString * const kTODOSyncErrorKey;
+
+/// Error status code included
+static NSInteger const kTODOErrorCodeGenericSyncFailedError = 301;
+
+extern NSString * const kTODOSyncFinishedNotificationName;
+
 @class TasksViewController;
 
 @interface TodoTxtAppDelegate : NSObject <UIApplicationDelegate, RemoteClientDelegate, UIActionSheetDelegate, UIAlertViewDelegate>
@@ -65,12 +73,12 @@ static NSInteger const kTODOErrorCodeUploadError = 202;
 
 - (void)displayNotification:(NSString *)message;
 - (void)clearUserDefaults;
-- (RACSignal *)syncClient;
-- (void)syncClientForce:(BOOL)force subject:(RACSubject *)subject;
-- (RACSignal *)pushToRemote;
-- (void)pushToRemoteOverwrite:(BOOL)overwrite force:(BOOL)force subject:(RACSubject *)subject;
-- (void)pullFromRemoteForce:(BOOL)force subject:(RACSubject *)subject;
-- (RACSignal *)pullFromRemote;
+- (void)syncClient;
+- (void)syncClientForce:(BOOL)force;
+- (void)pushToRemote;
+- (void)pushToRemoteOverwrite:(BOOL)overwrite force:(BOOL)force;
+- (void)pullFromRemoteForce:(BOOL)force;
+- (void)pullFromRemote;
 - (BOOL)isManualMode;
 - (void)logout;
 

--- a/Views/TaskCell.m
+++ b/Views/TaskCell.m
@@ -208,23 +208,17 @@ static const CGFloat kAgeLabelTopOffsetLessThan7 = -15;
         
         // Add/remove the age label based on showDateSignal, and tell the view
         // to layout afterwards.
-        [[RACSignal merge:@[
-          [[showDateSignal filter:^BOOL(NSNumber *boolNumber) {
-            return [boolNumber isEqual:@YES];
-        }] doNext:^(id _) {
-            [self.contentView addSubview:self.ageLabel];
-            [self.contentView addConstraints:@[ ageLabelTop, ageLabelLeft, ageLabelHeight ]];
-        }],
-          [[showDateSignal filter:^BOOL(NSNumber *boolNumber) {
-            return [boolNumber isEqual:@NO];
-        }] doNext:^(id _) {
-            [self.contentView removeConstraints:@[ ageLabelTop, ageLabelLeft, ageLabelHeight ]];
-            [self.ageLabel removeFromSuperview];
-        }],
-          ]]
-         subscribeNext:^(id _) {
-             [self setNeedsDisplay];
-         }];
+        [showDateSignal subscribeNext:^(NSNumber *boolNumber) {
+            if (boolNumber.boolValue) {
+                [self.contentView addSubview:self.ageLabel];
+                [self.contentView addConstraints:@[ ageLabelTop, ageLabelLeft, ageLabelHeight ]];
+            } else {
+                [self.contentView removeConstraints:@[ ageLabelTop, ageLabelLeft, ageLabelHeight ]];
+                [self.ageLabel removeFromSuperview];
+            }
+            
+            [self setNeedsDisplay];
+        }];
     }
     
     return self;


### PR DESCRIPTION
I think I made a mistake using ReactiveCocoa before, so I'm seeing about removing it and mostly restoring the previous syncing logic.

If you agree, I can remove it as a dependency entirely without much trouble in another PR.
