### PR TITLE
Fix Deprecated UI/NS elements

### DIFF
--- a/Classes/ActionSheetPicker.m
+++ b/Classes/ActionSheetPicker.m
@@ -140,7 +140,7 @@
 	if (nil != self.title){
 		UILabel *toolBarItemlabel = [[UILabel alloc]initWithFrame:CGRectMake(0, 0, 180,30)];
 		
-		[toolBarItemlabel setTextAlignment:UITextAlignmentCenter];	
+		[toolBarItemlabel setTextAlignment:NSTextAlignmentCenter];
 		[toolBarItemlabel setTextColor:[UIColor whiteColor]];	
 		[toolBarItemlabel setFont:[UIFont boldSystemFontOfSize:16]];	
 		[toolBarItemlabel setBackgroundColor:[UIColor clearColor]];	

--- a/Libraries/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/Libraries/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -325,7 +325,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 	if ((title = [self tableView:tableView titleForHeaderInSection:section])) {
 		CGSize size = [title sizeWithFont:[UIFont boldSystemFontOfSize:[UIFont labelFontSize]] 
 						constrainedToSize:CGSizeMake(tableView.frame.size.width - 2*kIASKHorizontalPaddingGroupTitles, INFINITY)
-							lineBreakMode:UILineBreakModeWordWrap];
+							lineBreakMode:NSLineBreakByWordWrapping];
 		return size.height+kIASKVerticalPaddingGroupTitles;
 	}
 	return 0;
@@ -429,7 +429,7 @@ CGRect IASKCGRectSwap(CGRect rect);
                                                                                       owner:self 
                                                                                     options:nil] objectAtIndex:0];
 
-            cell.textField.textAlignment = UITextAlignmentLeft;
+            cell.textField.textAlignment = NSTextAlignmentLeft;
             cell.textField.returnKeyType = UIReturnKeyDone;
             cell.accessoryType = UITableViewCellAccessoryNone;
         }
@@ -513,7 +513,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 			cell.backgroundColor = [UIColor whiteColor];
         }
         cell.textLabel.text = [specifier title];
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         return cell;
     } else if ([[specifier type] isEqualToString:kIASKMailComposeSpecifier]) {
         UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:[specifier type]];
@@ -704,7 +704,7 @@ CGRect IASKCGRectSwap(CGRect rect);
             }
             
             mailViewController.mailComposeDelegate = vc;
-            [vc presentModalViewController:mailViewController animated:YES];
+            [vc presentViewController:mailViewController animated:YES completion:nil];
             [mailViewController release];
         } else {
             UIAlertView *alert = [[UIAlertView alloc]
@@ -728,7 +728,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 
 -(void)mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error {
     // NOTE: No error handling is done here
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark -

--- a/Libraries/InAppSettingsKit/Controllers/IASKAppSettingsWebViewController.m
+++ b/Libraries/InAppSettingsKit/Controllers/IASKAppSettingsWebViewController.m
@@ -122,7 +122,7 @@
 		
 		[mailViewController setToRecipients:toRecipients];
 
-		[self presentModalViewController:mailViewController animated:YES];
+		[self presentViewController:mailViewController animated:YES completion:nil];
 		[mailViewController release];
 		return NO;
 	}
@@ -136,7 +136,7 @@
 }
 
 - (void)mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error {
-	[self dismissModalViewControllerAnimated:YES];
+	[self dismissViewControllerAnimated:YES completion:nil];
 }
 
 

--- a/Libraries/MBProgressHUD/MBProgressHUD.m
+++ b/Libraries/MBProgressHUD/MBProgressHUD.m
@@ -334,7 +334,7 @@
         // Set label properties
         label.font = self.labelFont;
         label.adjustsFontSizeToFitWidth = NO;
-        label.textAlignment = UITextAlignmentCenter;
+        label.textAlignment = NSTextAlignmentCenter;
         label.opaque = NO;
         label.backgroundColor = [UIColor clearColor];
         label.textColor = [UIColor whiteColor];
@@ -375,7 +375,7 @@
             // Set label properties
             detailsLabel.font = self.detailsLabelFont;
             detailsLabel.adjustsFontSizeToFitWidth = NO;
-            detailsLabel.textAlignment = UITextAlignmentCenter;
+            detailsLabel.textAlignment = NSTextAlignmentCenter;
             detailsLabel.opaque = NO;
             detailsLabel.backgroundColor = [UIColor clearColor];
             detailsLabel.textColor = [UIColor whiteColor];


### PR DESCRIPTION
Since 6.0, several of the `UIText*` and ViewController references have been deprecated - fixed up the issues for a more clean compile.
