### PR TITLE
Correct text highlighting for completed tasks

### DIFF
--- a/Classes/Task.h
+++ b/Classes/Task.h
@@ -91,7 +91,7 @@
 - (NSComparisonResult) compareByIdDescending:(Task*)other;
 - (NSComparisonResult) compareByPriority:(Task*)other;
 - (NSComparisonResult) compareByTextAscending:(Task*)other;
-- (NSArray *)rangesOfContexts;
-- (NSArray *)rangesOfProjects;
+- (NSArray *)rangesOfContexts:(NSString *)taskText;
+- (NSArray *)rangesOfProjects:(NSString *)taskText;
 
 @end

--- a/Classes/Task.m
+++ b/Classes/Task.m
@@ -326,14 +326,14 @@
 	return [self compareByIdDescending:other];
 }
 
-- (NSArray *)rangesOfContexts
+- (NSArray *)rangesOfContexts:(NSString *)taskText
 {
-    return [ContextParser rangesOfContextsForString:self.text];
+    return [ContextParser rangesOfContextsForString:taskText];
 }
 
-- (NSArray *)rangesOfProjects
+- (NSArray *)rangesOfProjects:(NSString *)taskText
 {
-    return [ProjectParser rangesOfProjectsForString:self.text];
+    return [ProjectParser rangesOfProjectsForString:taskText];
 }
 
 @end

--- a/View Models/TaskCellViewModel.m
+++ b/View Models/TaskCellViewModel.m
@@ -86,8 +86,8 @@
     
     NSDictionary *grayAttribute = @{ NSForegroundColorAttributeName : [UIColor grayColor] };
     
-    NSArray *contextsRanges = [self.task rangesOfContexts];
-    NSArray *projectsRanges = [self.task rangesOfProjects];
+    NSArray *contextsRanges = [self.task rangesOfContexts:taskText];
+    NSArray *projectsRanges = [self.task rangesOfProjects:taskText];
     for (NSValue *rangeValue in [contextsRanges arrayByAddingObjectsFromArray:projectsRanges]) {
         NSRange range = rangeValue.rangeValue;
         [taskString addAttributes:grayAttribute range:range];


### PR DESCRIPTION
When rangesOfProjects or rangesOfContexts compute the location for
highlighting projects or contexts within a task description, they
always used the task 'text' attribute. However, when a task was
completed there is additional text prepended in the displayed text.
This caused the highlighting to be displayed in the wrong place.

This patch changes the range computation to use the actual displayed
text instead of the 'text' attribute.
